### PR TITLE
fix: redirect Join as a Pro CTA to worker registration page

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -49,7 +49,7 @@ const Navbar = () => {
                   Log in
                 </Link>
                 <Link
-                  to="/register"
+                  to="/worker-register"
                   className="bg-[#0056D2] hover:bg-[#0047AF] text-white px-5 py-2.5 rounded-xl text-sm font-bold shadow-sm transition-all duration-200 hover:shadow-md"
                 >
                   Join as a Pro

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -199,7 +199,7 @@ const Home = () => {
                     Find a Pro
                   </Link>
                   <Link
-                    to="/register"
+                    to="/worker-register"
                     className="inline-flex items-center justify-center rounded-lg bg-white px-5 py-2 text-sm font-semibold text-slate-800 border border-slate-300 hover:bg-slate-50 transition"
                   >
                     Become a Pro
@@ -381,7 +381,7 @@ const Home = () => {
               Find a Pro
             </Link>
             <Link
-              to="/register"
+              to="/worker-register"
               className="bg-transparent border border-white/40 text-white px-8 py-3 rounded-xl font-semibold hover:bg-white/10 transition"
             >
               Become a Pro


### PR DESCRIPTION
## Description
Fixed the "Join as a Pro" CTA button redirect issue.

Previously, clicking the button redirected users to the general user registration page instead of the worker registration page.

## Changes Made
- Updated navbar "Join as a Pro" button route
- Updated homepage CTA button route
- Redirected both buttons to:

```
/worker-register
```

## Expected Behavior
Users who want to become service providers/workers are now redirected directly to the worker registration form.

closes #90 issue 