### PR TITLE
Add Workflows for issue labelling, welcome message, and stale cleanup

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,17 @@
+name: Auto Label Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: needs-review

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: Mark Stale Issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"   # runs daily
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 7
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-issue-message: "This issue has been marked as stale due to inactivity."
+          close-issue-message: "Closing this issue due to inactivity."
+          exempt-issue-labels: "in-progress,important"

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,19 @@
+name: Welcome New Issues
+
+on:
+  issues:
+    types: [opened]
+permissions:
+  issues: write
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add welcome comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            👋 Thanks for opening this issue!
+            
+             A maintainer will review it soon. Please make sure you've provided all necessary details.


### PR DESCRIPTION
### Summary
Adds GitHub Actions workflows to automate issue management.

### Changes
- Auto-label new issues with `needs-review`
- Add a welcome comment on new issues
- Mark inactive issues as stale and close them after a period

### Testing
Tested by creating a sample issue in fork:
- Label and comment worked as expected

### Note
The stale workflow uses a `stale` label, which may need to be created or adjusted based on repository preferences.