### PR TITLE
feat: add Back to Top button component

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -19,6 +19,7 @@ import TermsOfService from './pages/TermsOfService';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import NotFound from "./pages/NotFound";
 import FAQ from "./pages/FAQ";
+import BackToTop from './components/BackToTop';
 
 function AppContent() {
   const location = useLocation();
@@ -51,6 +52,7 @@ function AppContent() {
           <Route path="*" element={<NotFound />} />
         </Routes>
       </main>
+      <BackToTop /> 
       <Footer />
     </div>
   );

--- a/client/src/components/BackToTop.jsx
+++ b/client/src/components/BackToTop.jsx
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+
+const BackToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-8 right-8 z-50 bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-full shadow-lg transition-all duration-300"
+      aria-label="Back to top"
+    >
+      ↑
+    </button>
+  );
+};
+
+export default BackToTop;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,7 @@
         "mongoose": "^7.5.0"
       },
       "devDependencies": {
-        "nodemon": "^3.0.1"
+        "nodemon": "^3.1.14"
       }
     },
     "node_modules/@mongodb-js/saslprep": {


### PR DESCRIPTION
> This contribution is being made under **NSoC '26**.

## Summary
Adds a "Back to Top" button that appears when the user scrolls down 
more than 300px on any page, allowing quick navigation back to the top.

## Changes Made
- Created `client/src/components/BackToTop.jsx`
- Imported and added `<BackToTop />` in `App.jsx`

## Behavior
- Button appears after scrolling 300px down
- Smoothly scrolls back to top on click
- Hidden at the top of the page
- Works on all pages and is fully responsive

## Screenshots
<img width="1920" height="905" alt="Screenshot 2026-05-09 030033" src="https://github.com/user-attachments/assets/cc8ca4ab-3be4-4de5-a0d2-22e61fb5da41" />


Closes #139