### PR TITLE
fix: persist authenticated user state after registration

### DIFF
--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -37,7 +37,12 @@ export const AuthProvider = ({ children }) => {
   }, []);
 
   const value = {
-    user: authData ? { _id: authData._id, name: authData.name, email: authData.email } : null,
+    user: authData ? {
+      _id: authData._id,
+      name: authData.name,
+      email: authData.email,
+      phone: authData.phone,
+    } : null,
     token: authData?.token ?? null,
     isAuthenticated: !!authData?.token,
     login,

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,50 +1,100 @@
 import { useState } from "react";
+import { useAuth } from "../context/AuthContext";
 
 const Profile = () => {
+  const { user } = useAuth();
+
   const [loading, setLoading] = useState(false);
+
+  const [formData, setFormData] = useState({
+    name: user?.name || "",
+    email: user?.email || "",
+    phone: user?.phone || "",
+  });
 
   const handleSave = async () => {
     setLoading(true);
+
     try {
       // TODO: Handle API update logic
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
+      await new Promise((resolve) => setTimeout(resolve, 1000));
     } catch (error) {
-      console.error('Save failed:', error);
+      console.error("Save failed:", error);
     } finally {
       setLoading(false);
     }
   };
 
-  // TODO: (50% built) Load authenticated user's data from global state or API.
-  // Example: const { user } = useAuth();
-  
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-      <h1 className="text-3xl font-bold text-gray-900 mb-8">My Settings</h1>
-      
+      <h1 className="text-3xl font-bold text-gray-900 mb-8">
+        My Settings
+      </h1>
+
       <div className="bg-white shadow rounded-lg p-6">
         <form className="space-y-6">
-          {/* TODO: Tie inputs to component state and handle form submission */}
           <div>
-            <label className="block text-sm font-medium text-gray-700">Full Name</label>
-            <input type="text" defaultValue="John Customer" className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" />
+            <label className="block text-sm font-medium text-gray-700">
+              Full Name
+            </label>
+
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  name: e.target.value,
+                })
+              }
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700">Email Address</label>
-            <input type="email" defaultValue="john@example.com" disabled className="mt-1 block w-full px-3 py-2 border border-gray-200 bg-gray-50 rounded-md shadow-sm text-gray-500 sm:text-sm cursor-not-allowed" />
-            <p className="mt-1 text-xs text-gray-500">Email cannot be changed.</p>
+            <label className="block text-sm font-medium text-gray-700">
+              Email Address
+            </label>
+
+            <input
+              type="email"
+              value={formData.email}
+              disabled
+              className="mt-1 block w-full px-3 py-2 border border-gray-200 bg-gray-50 rounded-md shadow-sm text-gray-500 sm:text-sm cursor-not-allowed"
+            />
+
+            <p className="mt-1 text-xs text-gray-500">
+              Email cannot be changed.
+            </p>
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700">Phone Number</label>
-            <input type="tel" placeholder="(555) 123-4567" className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" />
+            <label className="block text-sm font-medium text-gray-700">
+              Phone Number
+            </label>
+
+            <input
+              type="tel"
+              value={formData.phone}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  phone: e.target.value,
+                })
+              }
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+            />
           </div>
 
           <div className="pt-4 border-t border-gray-200">
-            <button type="button" onClick={handleSave} disabled={loading} className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded shadow disabled:opacity-50 disabled:cursor-not-allowed">
-              <span className={`btn-text ${loading ? 'hidden' : ''}`}>Save Changes</span>
-              <span className={`btn-loader ${loading ? '' : 'hidden'}`}>Loading...</span>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={loading}
+              className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded shadow disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "Saving..." : "Save Changes"}
+              
             </button>
           </div>
         </form>

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -138,7 +138,10 @@ const Register = () => {
         password: formData.password,
       });
 
-      login(userData);
+      login({
+        ...userData,
+        phone: formData.phone,
+      });
       showToast("Registration successful! Welcome to FixNearby.");
 
       setFormData({ name: "", email: "", phone: "", password: "" });


### PR DESCRIPTION
## Changes Made

- Updated AuthContext after successful registration
- Persisted authenticated user data in localStorage
- Fixed profile/settings page to display real authenticated user data
- Added phone number persistence in auth state
- Fixed profile data persistence after page refresh
- Replaced hardcoded placeholder profile values
- Fixed Save Changes button text visibility

## Result

- Users remain authenticated after registration and refresh
- Profile page now displays actual logged-in user information
- Auth state stays synchronized across the application

closes #172 