### PR TITLE
Feature/worker portfolio section

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -255,21 +255,6 @@ const Home = () => {
 
   return (
     <div className="bg-white">
-      {/* HERO */}
-      <section className="relative">
-        <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8">
-          <div className="relative rounded-[36px] overflow-hidden shadow-2xl min-h-[500px]">
-            <img
-              src="/hero-section.png"
-              alt="Hero"
-              className="absolute inset-0 w-full h-full object-cover"
-            />
-
-            <div className="absolute inset-0 bg-black/50 flex items-center justify-center text-center">
-              <div className="text-white max-w-3xl px-6">
-                <h1 className="text-4xl sm:text-5xl md:text-6xl font-extrabold leading-tight tracking-tight">
-                  Trusted Home Services Near You
-                </h1>
       {/* HERO SECTION */}
       <section className="relative overflow-hidden bg-white">
         <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 sm:py-16 lg:px-8">
@@ -322,7 +307,6 @@ const Home = () => {
 
       {/* STATS SECTION */}
       <section className="py-20 bg-slate-50">
-        <div className="max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 grid grid-cols-2 md:grid-cols-4 gap-6">
         <div className="mx-auto max-w-7xl px-4 grid grid-cols-2 gap-6 md:grid-cols-4">
           {[
             { number: "10K+", label: "Happy Customers" },
@@ -331,8 +315,6 @@ const Home = () => {
             { number: "4.9/5", label: "Rating" },
           ].map((item) => (
             <div
-              key={idx}
-              className="bg-white rounded-3xl p-8 text-center shadow-sm border flex flex-col justify-center min-h-[180px]"
               key={item.label}
               className="rounded-3xl border border-slate-200 bg-white p-8 text-center shadow-sm transition hover:shadow-xl"
             >
@@ -375,43 +357,6 @@ const Home = () => {
               </Link>
             </div>
 
-            <Link
-              to="/services"
-              className="text-blue-600 font-semibold hover:underline"
-            >
-              View All →
-            </Link>
-          </div>
-
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 items-stretch">
-            {workers.map((worker) => {
-              const WorkerIcon =
-                workerIconMap[worker.profession] || IconBolt;
-
-              return (
-                <div
-                  key={worker.id}
-                  className="bg-white border rounded-3xl p-6 shadow-sm hover:shadow-xl transition flex flex-col h-full"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="w-14 h-14 rounded-2xl bg-slate-100 flex items-center justify-center">
-                      <WorkerIcon className="w-8 h-8 text-slate-900" />
-                    </div>
-
-                    <span
-                      className={`text-xs font-semibold px-3 py-1 rounded-full ${
-                        worker.available
-                          ? "bg-emerald-100 text-emerald-700"
-                          : "bg-red-100 text-red-600"
-                      }`}
-                    >
-                      {worker.available ? "Available" : "Busy"}
-                    </span>
-                  </div>
-
-                  <h3 className="mt-5 text-xl font-bold text-slate-900">
-                    {worker.name}
-                  </h3>
             {geoLoading && (
               <div className="py-12 text-center font-medium text-slate-500">
                 Requesting location permission...
@@ -424,22 +369,6 @@ const Home = () => {
               </div>
             )}
 
-                  <div className="flex items-center justify-between mt-5 text-sm mb-6">
-                    <span>⭐ {worker.rating}</span>
-                    <span className="font-semibold">
-                      {worker.price}
-                    </span>
-                  </div>
-
-                  <Link
-                    to={`/worker/${worker.id}`}
-                    className="mt-auto block text-center bg-slate-900 hover:bg-blue-600 text-white py-3 rounded-xl font-semibold transition"
-                  >
-                    Book Now
-                  </Link>
-                </div>
-              );
-            })}
             {coords && nearbyWorkers.length > 0 && (
               <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
                 {nearbyWorkers.map((worker) => {
@@ -506,8 +435,6 @@ const Home = () => {
           <h2 className="mb-4 text-5xl font-extrabold text-slate-900">
             How it works
           </h2>
-
-          <div className="grid md:grid-cols-3 gap-8 mt-16 items-stretch">
           <p className="mb-16 text-lg text-slate-600">
             Three simple steps to get it done.
           </p>
@@ -531,13 +458,6 @@ const Home = () => {
                 desc: "Let the expert handle the job.",
                 IconComp: IconCheckCircle,
               },
-            ].map((item) => (
-              <div
-                key={item.step}
-                className="bg-white rounded-3xl p-10 border shadow-sm flex flex-col items-center text-center h-full"
-              >
-                <div className="w-16 h-16 rounded-full bg-blue-600 text-white flex items-center justify-center text-2xl font-bold mx-auto">
-                  {item.step}
             ].map((step) => (
               <div key={step.step} className="relative">
                 <div className="mx-auto mb-6 flex h-[92px] w-[92px] items-center justify-center rounded-full border border-slate-200 bg-white shadow-sm">
@@ -555,15 +475,6 @@ const Home = () => {
         </div>
       </section>
 
-      {/* CTA */}
-      <section className="py-24 bg-blue-600 text-white text-center">
-        <div className="max-w-3xl mx-auto px-6 flex flex-col items-center">
-          <h2 className="text-5xl font-extrabold">
-            Need Help Today?
-          </h2>
-
-          <p className="mt-5 text-lg text-blue-100">
-            Hire trusted professionals in minutes.
       {/* CTA SECTION */}
       <section className="bg-[#0056D2] py-20 text-center text-white">
         <div className="mx-auto max-w-3xl px-4">

--- a/client/src/pages/Services.jsx
+++ b/client/src/pages/Services.jsx
@@ -2,33 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import LoadingSpinner from "../components/LoadingSpinner";
 
-const categories = [
-  "All",
-  "Electrician",
-  "Plumber",
-  "Carpenter",
-  "Painter",
-  "AC Technician",
-  "Cleaner",
-  "Mechanic",
-  "Gardener",
-  "Appliance Repair",
-  "Pest Control",
-];
-
-const iconMap = {
-  Electrician: "⚡",
-  Plumber: "🚰",
-  Carpenter: "🪵",
-  Painter: "🎨",
-  "AC Technician": "❄️",
-  Cleaner: "🧹",
-  Mechanic: "🔧",
-  Gardener: "🌱",
-  "Appliance Repair": "🔌",
-  "Pest Control": "🐜",
-};
-
 const mockWorkers = [
   {
     id: 1,
@@ -69,28 +42,138 @@ const mockWorkers = [
     mockOffset: { lat: 0.03, lon: -0.015 },
     verified: true,
   },
+  {
+    id: 4,
+    name: "Ravi Kumar",
+    profession: "Painter",
+    rating: 4.6,
+    price: 30,
+    availability: "Next slot tomorrow",
+    responseTime: "Replies in 25 min",
+    outcomeText: "Check service details and move straight into booking when ready.",
+    mockOffset: { lat: -0.022, lon: -0.01 },
+    verified: true,
+  },
+  {
+    id: 5,
+    name: "Amit Sharma",
+    profession: "AC Technician",
+    rating: 4.7,
+    price: 45,
+    availability: "Emergency slots open",
+    responseTime: "Replies in 10 min",
+    outcomeText: "View service scope, urgency fit, and book an AC repair visit quickly.",
+    mockOffset: { lat: 0.008, lon: -0.025 },
+    verified: true,
+  },
+  {
+    id: 6,
+    name: "Suresh Patel",
+    profession: "Cleaner",
+    rating: 4.3,
+    price: 25,
+    availability: "Weekend availability",
+    responseTime: "Replies in 30 min",
+    outcomeText:
+      "Open the profile to compare rates and schedule a cleaning appointment.",
+    mockOffset: { lat: 0.05, lon: 0.03 },
+    verified: true,
+  },
+  {
+    id: 7,
+    name: "David Lee",
+    profession: "Mechanic",
+    rating: 4.8,
+    price: 55,
+    availability: "Available this evening",
+    responseTime: "Replies in 20 min",
+    outcomeText:
+      "See diagnostic pricing and book a mechanic visit with clearer expectations.",
+    mockOffset: { lat: -0.04, lon: 0.015 },
+    verified: true,
+  },
+  {
+    id: 8,
+    name: "Priya Singh",
+    profession: "Gardener",
+    rating: 4.4,
+    price: 20,
+    availability: "Morning slots open",
+    responseTime: "Replies in 40 min",
+    outcomeText:
+      "Review service options and book a gardener for regular or one-time visits.",
+    mockOffset: { lat: 0.003, lon: 0.004 },
+    verified: true,
+  },
+  {
+    id: 9,
+    name: "Imran Khan",
+    profession: "Appliance Repair",
+    rating: 4.6,
+    price: 35,
+    availability: "Next slot tomorrow",
+    responseTime: "Replies in 25 min",
+    outcomeText:
+      "Open the profile to check appliance support and request a repair appointment.",
+    mockOffset: { lat: -0.018, lon: -0.03 },
+    verified: true,
+  },
+  {
+    id: 10,
+    name: "Neha Gupta",
+    profession: "Pest Control",
+    rating: 4.5,
+    price: 40,
+    availability: "Inspection slots open",
+    responseTime: "Replies in 15 min",
+    outcomeText:
+      "View treatment details and book an inspection without leaving the flow.",
+    mockOffset: { lat: 0.025, lon: -0.005 },
+    verified: true,
+  },
 ];
+
+const categories = [
+  "All",
+  "Electrician",
+  "Plumber",
+  "Carpenter",
+  "Painter",
+  "AC Technician",
+  "Cleaner",
+  "Mechanic",
+  "Gardener",
+  "Appliance Repair",
+  "Pest Control",
+];
+
+const iconMap = {
+  Electrician: "⚡",
+  Plumber: "🚰",
+  Carpenter: "🪵",
+  Painter: "🎨",
+  "AC Technician": "❄️",
+  Cleaner: "🧹",
+  Mechanic: "🔧",
+  Gardener: "🌱",
+  "Appliance Repair": "🔌",
+  "Pest Control": "🐜",
+};
 
 const getDistanceKm = (lat1, lon1, lat2, lon2) => {
   const radiusKm = 6371;
   const dLat = ((lat2 - lat1) * Math.PI) / 180;
   const dLon = ((lon2 - lon1) * Math.PI) / 180;
-
   const a =
     Math.sin(dLat / 2) ** 2 +
     Math.cos((lat1 * Math.PI) / 180) *
       Math.cos((lat2 * Math.PI) / 180) *
       Math.sin(dLon / 2) ** 2;
-
   return radiusKm * (2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
 };
 
-
 const formatDistance = (distance) => {
-  if (distance < 1) {
-    return `${Math.round(distance * 1000)} m`;
-  }
-
+  if (distance < 1) return `${Math.round(distance * 1000)} m`;
   return `${distance.toFixed(1)} km`;
 };
 
@@ -100,11 +183,9 @@ const Services = () => {
   const [searchQuery, setSearchQuery] = useState(
     searchParams.get("search") || "",
   );
-
   const [categoryFilter, setCategoryFilter] = useState(
     searchParams.get("category") || "All",
   );
-
   const [sortBy, setSortBy] = useState(searchParams.get("sort") || "distance");
 
   const [loading, setLoading] = useState(true);
@@ -114,78 +195,19 @@ const Services = () => {
   const [coords, setCoords] = useState(null);
   const [locationStatus, setLocationStatus] = useState("idle");
 
-
-  const SERVICE_CATEGORIES = [
-  {
-    name: "Electrician",
-    icon: "⚡",
-  },
-  {
-    name: "Plumber",
-    icon: "🚰",
-  },
-  {
-    name: "Carpenter",
-    icon: "🪵",
-  },
-  {
-    name: "Painter",
-    icon: "🎨",
-  },
-  {
-    name: "AC Technician",
-    icon: "❄️",
-  },
-  {
-    name: "Cleaner",
-    icon: "🧹",
-  },
-  {
-    name: "Mechanic",
-    icon: "🔧",
-  },
-  {
-    name: "Gardener",
-    icon: "🌱",
-  },
-  {
-    name: "Appliance Repair",
-    icon: "🔌",
-  },
-  {
-    name: "Pest Control",
-    icon: "🐜",
-  },
-];
-
-  const categories = [
-    "All",
-    "Electrician",
-    "Plumber",
-    "Carpenter",
-    "Painter",
-    "AC Technician",
-    "Cleaner",
-    "Mechanic",
-    "Gardener",
-    "Appliance Repair",
-    "Pest Control",
-  ];
+  // GEOLOCATION
   useEffect(() => {
     if (!navigator.geolocation) {
       setLocationStatus("unsupported");
       return;
     }
-
     setLocationStatus("loading");
-
     navigator.geolocation.getCurrentPosition(
       (position) => {
         setCoords({
           latitude: position.coords.latitude,
           longitude: position.coords.longitude,
         });
-
         setLocationStatus("success");
       },
       () => {
@@ -194,50 +216,34 @@ const Services = () => {
     );
   }, []);
 
+  // LOAD WORKERS
   useEffect(() => {
     setLoading(true);
-
     const timer = window.setTimeout(() => {
       setWorkers(mockWorkers);
-
       const storedRecent =
         JSON.parse(localStorage.getItem("recentWorkers")) || [];
-
       setRecentWorkers(storedRecent);
-
       setLoading(false);
     }, 500);
-
     return () => window.clearTimeout(timer);
   }, []);
 
+  // SYNC URL PARAMS
   useEffect(() => {
     const params = {};
-
-    if (searchQuery) {
-      params.search = searchQuery;
-    }
-
-    if (categoryFilter !== "All") {
-      params.category = categoryFilter;
-    }
-
-    if (sortBy !== "distance") {
-      params.sort = sortBy;
-    }
-
+    if (searchQuery) params.search = searchQuery;
+    if (categoryFilter !== "All") params.category = categoryFilter;
+    if (sortBy !== "distance") params.sort = sortBy;
     setSearchParams(params);
   }, [categoryFilter, searchQuery, setSearchParams, sortBy]);
 
+  // FILTER + SORT
   const filteredWorkers = useMemo(() => {
     let result = workers.map((worker) => {
-      if (!coords) {
-        return { ...worker, distanceKm: null };
-      }
-
+      if (!coords) return { ...worker, distanceKm: null };
       const workerLat = coords.latitude + worker.mockOffset.lat;
       const workerLon = coords.longitude + worker.mockOffset.lon;
-
       return {
         ...worker,
         distanceKm: getDistanceKm(
@@ -249,75 +255,14 @@ const Services = () => {
       };
     });
 
-    {/* POPULAR CATEGORIES */}
-
-<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-
-  <div className="flex items-center justify-between mb-8">
-
-    <div>
-      <h2 className="text-3xl font-bold text-slate-900">
-        Popular Categories
-      </h2>
-
-      <p className="text-slate-500 mt-2">
-        Browse professionals by category
-      </p>
-    </div>
-
-  </div>
-
-  <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-5">
-
-    {SERVICE_CATEGORIES.map((category) => (
-      <button
-        key={category.name}
-        onClick={() => setCategoryFilter(category.name)}
-        className={`group rounded-3xl p-6 border transition-all duration-300 hover:-translate-y-1 hover:shadow-xl
-        ${
-          categoryFilter === category.name
-            ? "bg-blue-600 border-blue-600 text-white"
-            : "bg-white border-slate-200 text-slate-900"
-        }`}
-      >
-
-        <div className="text-5xl mb-4 group-hover:scale-110 transition">
-          {category.icon}
-        </div>
-
-        <h3 className="font-bold text-lg">
-          {category.name}
-        </h3>
-
-      </button>
-    ))}
-
-  </div>
-
-</div>
-
-    // SEARCH
-
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase();
-
-      result = result.filter(
-        (w) =>
-          w.name.toLowerCase().includes(q) ||
-          w.profession.toLowerCase().includes(q)
-      );
-    }
     result = result.filter((worker) => {
       const search = searchQuery.trim().toLowerCase();
-
       const matchesSearch =
         !search ||
         worker.name.toLowerCase().includes(search) ||
         worker.profession.toLowerCase().includes(search);
-
       const matchesCategory =
         categoryFilter === "All" || worker.profession === categoryFilter;
-
       return matchesSearch && matchesCategory;
     });
 
@@ -334,84 +279,20 @@ const Services = () => {
 
   const handleRecentlyViewed = (worker) => {
     let stored = JSON.parse(localStorage.getItem("recentWorkers")) || [];
-
     stored = stored.filter((item) => item.id !== worker.id);
-
     stored.unshift(worker);
-
     stored = stored.slice(0, 5);
-
     localStorage.setItem("recentWorkers", JSON.stringify(stored));
-
-            </div>
-      {/* HEADER */}
-      {/* HERO + SEARCH SECTION */}
-
-<section className="bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 text-white">
-
-  <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
-
-    <div className="max-w-3xl">
-
-      {/* LABEL */}
-
-      <div className="inline-flex items-center gap-2 bg-white/10 border border-white/20 px-4 py-2 rounded-full text-sm font-medium text-blue-100 mb-6">
-        🚀 Trusted Local Professionals
-      </div>
-
-      {/* TITLE */}
-
-      <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black leading-tight tracking-tight">
-        Find Skilled Professionals Near You
-      </h1>
-
-      {/* DESCRIPTION */}
-
-      <p className="text-slate-300 mt-6 text-lg leading-relaxed max-w-2xl">
-        Compare ratings, pricing and availability before booking trusted experts for your home services.
-      </p>
-
-      {/* SEARCH CONTAINER */}
-
-      <div className="bg-white rounded-3xl p-4 sm:p-5 mt-10 shadow-xl border border-white/10">
-
-        {/* SEARCH ROW */}
-
-        <div className="flex flex-col lg:flex-row gap-4">
-
-          {/* SEARCH INPUT */}
-
-          <div className="relative flex-1">
-
-            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 text-lg">
-              🔍
-            </span>
-
-            <input
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search electricians, plumbers..."
-              className="w-full pl-12 pr-4 py-4 rounded-2xl border border-slate-200 text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
-            />
-
-          </div>
-
-          {/* SORT */}
-
-          <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value)}
-            className="px-5 py-4 rounded-2xl border border-slate-200 text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
     setRecentWorkers(stored);
   };
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-12">
+      {/* HEADER */}
       <div className="mb-10 text-center">
         <h1 className="text-4xl font-bold text-gray-900">
           Find Reliable Services Near You
         </h1>
-
         <p className="mt-2 text-gray-500">
           {locationStatus === "success"
             ? "Showing nearby professionals"
@@ -421,106 +302,57 @@ const Services = () => {
         </p>
       </div>
 
+      {/* FILTERS */}
       <div className="mb-10 space-y-6">
         <div className="mx-auto flex max-w-3xl flex-col gap-4 sm:flex-row">
           <input
             type="text"
             value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
+            onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search by worker or service..."
             className="w-full flex-1 rounded-xl border border-gray-300 px-4 py-3 shadow-sm transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
           />
-
           <select
             value={sortBy}
-            onChange={(event) => setSortBy(event.target.value)}
+            onChange={(e) => setSortBy(e.target.value)}
             className="rounded-xl border border-gray-300 px-4 py-3 shadow-sm transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
           >
-            <option value="distance">
-              📍 Nearest
-            </option>
-
-            <option value="rating">
-              ⭐ Top Rated
-            </option>
-
-            <option value="price">
-              💰 Lowest Price
-            </option>
-
+            <option value="distance">📍 Nearest</option>
+            <option value="rating">⭐ Top Rated</option>
+            <option value="price">💰 Lowest Price</option>
           </select>
         </div>
 
         {/* CATEGORY PILLS */}
-
-        <div className="flex gap-3 mt-5 overflow-x-auto pb-1 scrollbar-hide">
-
+        <div className="flex flex-wrap justify-center gap-2">
           {categories.map((cat) => (
             <button
               key={cat}
               onClick={() => setCategoryFilter(cat)}
-              className={`
-                shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all duration-200
-                ${
-                  categoryFilter === cat
-                    ? "bg-blue-600 text-white shadow-md"
-                    : "bg-slate-100 text-slate-700 hover:bg-slate-200"
-                }
-              `}
-            >
-
-              {cat !== "All" && iconMap[cat] && (
-                <span className="mr-2">
-                  {iconMap[cat]}
-                </span>
-              )}
-
-              {cat}
-
-            </button>
-          ))}
-
-        </div>
-
-      </div>
-
-    </div>
-
-  </div>
-
-</section>
-        <div className="flex flex-wrap justify-center gap-2">
-          {categories.map((category) => (
-            <button
-              key={category}
-              type="button"
-              onClick={() => setCategoryFilter(category)}
               className={`rounded-full border px-5 py-2 text-sm font-semibold transition ${
-                categoryFilter === category
+                categoryFilter === cat
                   ? "border-blue-600 bg-blue-600 text-white"
                   : "border-gray-200 bg-white text-gray-600 hover:border-blue-400 hover:text-blue-600"
               }`}
             >
-              {category !== "All" && iconMap[category] && (
-                <span className="mr-2">{iconMap[category]}</span>
+              {cat !== "All" && iconMap[cat] && (
+                <span className="mr-2">{iconMap[cat]}</span>
               )}
-
-              {category}
+              {cat}
             </button>
           ))}
         </div>
       </div>
 
+      {/* RECENTLY VIEWED */}
       {recentWorkers.length > 0 && (
         <div className="mb-14">
           <div className="mb-6 flex items-center gap-2">
             <span className="text-2xl">⭐</span>
-
             <h2 className="text-2xl font-bold text-gray-900">
               Recently Viewed Professionals
             </h2>
           </div>
-
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {recentWorkers.map((worker) => (
               <div
@@ -530,18 +362,14 @@ const Services = () => {
                 <div className="mb-4 text-4xl">
                   {iconMap[worker.profession] || "👷"}
                 </div>
-
                 <h3 className="text-lg font-bold text-gray-900">
                   {worker.name}
                 </h3>
-
                 <p className="mb-3 font-medium text-blue-600">
                   {worker.profession}
                 </p>
-
                 <div className="flex items-center justify-between text-sm text-gray-600">
                   <span>⭐ {worker.rating}</span>
-
                   <span>${worker.price}/hr</span>
                 </div>
               </div>
@@ -550,16 +378,15 @@ const Services = () => {
         </div>
       )}
 
+      {/* WORKER CARDS */}
       {loading ? (
         <LoadingSpinner />
       ) : filteredWorkers.length === 0 ? (
         <div className="rounded-3xl border-2 border-dashed border-gray-200 bg-gray-50 py-20 text-center">
           <h3 className="text-2xl font-bold text-gray-900">No workers found</h3>
-
           <p className="mx-auto mt-2 max-w-md text-gray-500">
             Try a broader search or reset the selected category.
           </p>
-
           <button
             type="button"
             onClick={() => {
@@ -577,7 +404,6 @@ const Services = () => {
           <p className="mb-6 text-sm font-medium text-gray-500">
             Showing {filteredWorkers.length} professionals
           </p>
-
           <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
             {filteredWorkers.map((worker) => (
               <div
@@ -589,7 +415,6 @@ const Services = () => {
                     <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-blue-50 text-3xl text-blue-600">
                       {iconMap[worker.profession] || "👷"}
                     </div>
-
                     {worker.verified && (
                       <span className="rounded-full bg-green-50 px-3 py-1.5 text-xs font-bold text-green-700">
                         Verified
@@ -600,32 +425,6 @@ const Services = () => {
                   <h3 className="mb-1 text-2xl font-bold text-gray-900">
                     {worker.name}
                   </h3>
-
-                  <p className="text-blue-600 font-medium mt-1">
-                    {w.profession}
-                  </p>
-
-                </div>
-
-                <div
-                  className={`text-xs px-3 py-1 rounded-full font-semibold ${
-                    w.available
-                      ? "bg-emerald-100 text-emerald-700"
-                      : "bg-red-100 text-red-600"
-                  }`}
-                >
-                  {w.available ? "Available" : "Busy"}
-                </div>
-
-              </div>
-
-              {/* STATS */}
-
-              <div className="grid grid-cols-2 gap-4 mt-auto pt-6">
-
-                <div className="bg-slate-50 rounded-2xl p-4">
-                  <p className="text-xs text-slate-500 mb-1">
-                    Rating
                   <p className="mb-4 font-bold text-blue-600">
                     {worker.profession}
                   </p>
@@ -634,7 +433,6 @@ const Services = () => {
                     <span className="rounded-full bg-blue-50 px-3 py-1 text-blue-700">
                       {worker.availability}
                     </span>
-
                     <span className="rounded-full bg-emerald-50 px-3 py-1 text-emerald-700">
                       {worker.responseTime}
                     </span>
@@ -644,11 +442,9 @@ const Services = () => {
                     <span className="font-bold text-gray-900">
                       Rating {worker.rating}
                     </span>
-
                     <span className="font-bold text-gray-900">
                       ${worker.price}/hr
                     </span>
-
                     {worker.distanceKm !== null && (
                       <span className="font-bold text-gray-900">
                         {formatDistance(worker.distanceKm)}
@@ -661,601 +457,11 @@ const Services = () => {
                   </p>
                 </div>
 
-                {/* BUTTONS */}
-
-                <div className="grid grid-cols-2 gap-3">
-
-                  <button className="border border-slate-300 rounded-2xl py-3 font-medium hover:border-blue-500 hover:text-blue-600 transition">
-
-                    Chat Now
-
-                  </button>
-
-                  <Link
-                    to={`/worker/${w.id}`}
-                    className="bg-slate-900 text-white text-center py-3 rounded-2xl font-medium hover:bg-blue-600 transition"
-                  >
-                    {w.instantBooking
-                      ? "Book Instantly"
-                      : "Request Booking"}
-                  </Link>
-
-                </div>
-
-              </div>
-
-            </div>
-
-          </div>
-        )}
-
-        {/* LOADING */}
-
-        {loading ? (
-          <LoadingSpinner />
-        ) : processedWorkers.length === 0 ? (
-          <div className="bg-white border border-slate-200 rounded-3xl py-24 text-center">
-
-            <div className="text-7xl mb-6">
-              🔍
-            </div>
-
-            <h3 className="text-3xl font-bold text-slate-900">
-
-              No Professionals Found
-
-            </h3>
-
-            <p className="text-slate-500 mt-3">
-
-              Try another keyword or category filter
-
-            </p>
-
-          </div>
-        ) : (
-          <div className="grid grid-cols-[repeat(auto-fit,minmax(340px,1fr))] gap-8">
-
-            {processedWorkers.map((w) => (
-              <div
-                key={w.id}
-                className="group relative bg-white border border-slate-200 rounded-[30px] p-6 hover:shadow-2xl hover:-translate-y-2 transition-all duration-500 overflow-hidden"
-              >
-                 <div className="flex-1 flex flex-col">
-                {/* RECOMMENDED */}
-
-                {w.recommended && (
-                  <div className="absolute top-5 right-5 bg-gradient-to-r from-amber-400 to-orange-500 text-white text-xs font-bold px-3 py-1 rounded-full shadow-lg">
-
-                    ⭐ Recommended
-
-                  </div>
-                )}
-
-                {/* TOP */}
-
-                <div className="flex items-start gap-4">
-
-                  {/* ICON */}
-
-                  <div className="w-20 h-20 rounded-3xl bg-gradient-to-br from-blue-50 to-slate-100 flex items-center justify-center text-4xl shadow-inner shrink-0 group-hover:scale-110 transition duration-300">
-
-                    {iconMap[w.profession]}
-
-                  </div>
-
-                  {/* INFO */}
-
-                  <div className="flex-1 min-w-0">
-
-                    <div className="flex items-center gap-2 flex-wrap">
-
-                      <h3 className="text-2xl font-bold text-slate-900 leading-tight">
-
-                        {w.name}
-
-                      </h3>
-
-                      {w.verified && (
-                        <span className="bg-blue-100 text-blue-700 text-xs font-semibold px-2 py-1 rounded-full">
-
-                          ✓ Verified
-
-                        </span>
-                      )}
-
-                    </div>
-
-                    <p className="text-blue-600 font-semibold mt-1 text-lg min-h-[28px]">
-
-                      {w.profession}
-
-                    </p>
-
-                    {/* PRIMARY DECISION */}
-
-                    <div className="flex flex-wrap gap-2 mt-4">
-
-                      <div className="bg-amber-50 text-amber-700 px-3 py-1 rounded-full text-sm font-semibold">
-
-                        ⭐ {w.rating}
-
-                      </div>
-
-                      <div className="bg-emerald-50 text-emerald-700 px-3 py-1 rounded-full text-sm font-semibold">
-
-                        💰 ${w.price}/hr
-
-                      </div>
-
-                      <div className="bg-slate-100 text-slate-700 px-3 py-1 rounded-full text-sm font-semibold">
-
-                        🛠 {w.experience} yrs
-
-                      </div>
-
-                    </div>
-
-                  </div>
-
-                </div>
-
-                {/* AVAILABILITY */}
-
-                <div className="mt-6 flex items-center justify-between">
-
-                  <div
-                    className={`px-4 py-2 rounded-full text-sm font-bold ${
-                      w.available
-                        ? "bg-emerald-100 text-emerald-700"
-                        : "bg-rose-100 text-rose-600"
-                    }`}
-                  >
-                    {w.available
-                      ? "Available Now"
-                      : "Currently Busy"}
-                  </div>
-
-                  {w.distanceKm && (
-                    <div className="text-sm font-semibold text-slate-600">
-
-                      📍 {formatDistance(w.distanceKm)}
-
-                    </div>
-                  )}
-
-                </div>
-
-                {/* STATS */}
-
-                <div className="grid grid-cols-3 gap-3 mt-6 auto-rows-fr">
-
-                  <div className="bg-slate-50 rounded-2xl p-4 text-center">
-
-                    <p className="text-xs text-slate-500">
-                      Jobs
-                    </p>
-
-                    <h4 className="font-bold text-slate-900 mt-1">
-
-                      {w.completedJobs}+
-
-                    </h4>
-
-                  </div>
-
-                  <div className="bg-slate-50 rounded-2xl p-4 text-center">
-
-                    <p className="text-xs text-slate-500">
-                      Response
-                    </p>
-
-                    <h4 className="font-bold text-slate-900 mt-1">
-
-                      {w.responseTime}
-
-                    </h4>
-
-                  </div>
-
-                  <div className="bg-slate-50 rounded-2xl p-4 text-center">
-
-                    <p className="text-xs text-slate-500">
-                      Success
-                    </p>
-
-                    <h4 className="font-bold text-emerald-600 mt-1">
-
-                      {w.successRate}%
-
-                    </h4>
-
-                  </div>
-
-                </div>
-
-                {/* SERVICE DETAILS */}
-
-                <div className="mt-6 border-t border-slate-100 pt-6 space-y-4">
-
-                  <div className="flex items-center justify-between">
-
-                    <span className="text-slate-500 text-sm">
-
-                      🚀 Booking Type
-
-                    </span>
-
-                    <span
-                      className={`font-semibold text-sm ${
-                        w.instantBooking
-                          ? "text-emerald-600"
-                          : "text-orange-500"
-                      }`}
-                    >
-                      {w.instantBooking
-                        ? "Instant Confirmation"
-                        : "Approval Required"}
-                    </span>
-
-                  </div>
-
-                  <div className="flex items-center justify-between">
-
-                    <span className="text-slate-500 text-sm">
-
-                      ⏱ Arrival Time
-
-                    </span>
-
-                    <span className="font-semibold text-slate-900 text-sm">
-
-                      {w.arrivalTime}
-
-                    </span>
-
-                  </div>
-
-                  <div className="flex items-center justify-between">
-
-                    <span className="text-slate-500 text-sm">
-
-                      🛡 Warranty
-
-                    </span>
-
-                    <span className="font-semibold text-slate-900 text-sm">
-
-                      {w.serviceWarranty}
-
-                    </span>
-
-                  </div>
-
-                </div>
-
-                {/* OUTCOME BOX */}
-
-                <div className="mt-6 bg-blue-50 border border-blue-100 rounded-2xl p-4 min-h-[88px] flex items-center">
-
-                  <p className="text-sm leading-relaxed text-slate-700">
-
-                    {w.instantBooking
-                      ? `Book instantly and expect arrival within ${w.arrivalTime}.`
-                      : `Worker approval required before booking confirmation.`}
-
-                  </p>
-
-                </div>
-
-                {/* BUTTONS */}
-
-                <div className="grid grid-cols-2 gap-4 mt-6">
-
-                  <button className="border border-slate-300 rounded-2xl py-3.5 font-semibold hover:border-blue-500 hover:text-blue-600 transition-all">
-
-                    Chat Now
-
-                  </button>
-
-                  <Link
-                    to={`/worker/${w.id}`}
-                    className="bg-slate-900 text-white text-center py-3.5 rounded-2xl font-semibold hover:bg-blue-600 transition-all shadow-lg hover:shadow-blue-200"
-                  >
-                    {w.instantBooking
-                      ? "Book Instantly"
-                      : "Request Booking"}
-                  </Link>
-
-                </div>
-
-              </div>
-            ))}
-
-          </div>
-        )}
-
-      </div>
-
-    </div>
-  );
-};
-
-export default Services;
-import { Link, useSearchParams } from 'react-router-dom';
-import { useState, useEffect, useMemo } from 'react';
-import LoadingSpinner from '../components/LoadingSpinner';
-
-const Services = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-
-  // 🔗 URL Synced State
-  const [searchQuery, setSearchQuery] = useState(searchParams.get("search") || "");
-  const [categoryFilter, setCategoryFilter] = useState(searchParams.get("category") || "All");
-  const [sortBy, setSortBy] = useState(searchParams.get("sort") || "distance");
-
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [workers, setWorkers] = useState([]);
-
-  // 🌍 Location
-  const [coords, setCoords] = useState(null);
-  const [locationStatus, setLocationStatus] = useState("idle");
-
-  const categories = [
-    "All","Electrician","Plumber","Carpenter","Painter",
-    "AC Technician","Cleaner","Mechanic","Gardener",
-    "Appliance Repair","Pest Control"
-  ];
-
-  const iconMap = {
-    Electrician: "⚡", Plumber: "🚰", Carpenter: "🪵", Painter: "🎨",
-    "AC Technician": "❄️", Cleaner: "🧹", Mechanic: "🔧",
-    Gardener: "🌱", "Appliance Repair": "🔌", "Pest Control": "🐜",
-  };
-
-  const getDistanceKm = (lat1, lon1, lat2, lon2) => {
-    const R = 6371;
-    const dLat = (lat2 - lat1) * (Math.PI / 180);
-    const dLon = (lon2 - lon1) * (Math.PI / 180);
-    const a =
-      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-      Math.cos(lat1 * (Math.PI / 180)) * Math.cos(lat2 * (Math.PI / 180)) *
-      Math.sin(dLon / 2) * Math.sin(dLon / 2);
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-    return R * c;
-  };
-
-  const formatDistance = (dist) => {
-    if (dist < 1) return `${(dist * 1000).toFixed(0)}m`;
-    return `${dist.toFixed(1)}km`;
-  };
-
-  // 🌍 LOCATION
-  useEffect(() => {
-    if (!navigator.geolocation) {
-      setLocationStatus("unsupported");
-      return;
-    }
-
-    setLocationStatus("loading");
-
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        setCoords({
-          latitude: pos.coords.latitude,
-          longitude: pos.coords.longitude,
-        });
-        setLocationStatus("success");
-      },
-      () => setLocationStatus("denied")
-    );
-  }, []);
-
-  // 🔗 Sync URL
-  useEffect(() => {
-    const params = {};
-    if (searchQuery) params.search = searchQuery;
-    if (categoryFilter !== "All") params.category = categoryFilter;
-    if (sortBy !== "distance") params.sort = sortBy;
-
-    setSearchParams(params);
-  }, [searchQuery, categoryFilter, sortBy]);
-
-  // 📦 Mock Data
-  useEffect(() => {
-    setLoading(true);
-    setTimeout(() => {
-      setWorkers([
-        { id: 1, name: "John Doe", profession: "Electrician", rating: 4.8, price: 40, mockOffset: { lat: 0.012, lon: 0.008 }, verified: true },
-        { id: 2, name: "Jane Smith", profession: "Plumber", rating: 4.9, price: 50, mockOffset: { lat: -0.005, lon: 0.02 }, verified: true },
-        { id: 3, name: "Mike Johnson", profession: "Carpenter", rating: 4.5, price: 35, mockOffset: { lat: 0.03, lon: -0.015 }, verified: true },
-        { id: 4, name: "Ravi Kumar", profession: "Painter", rating: 4.6, price: 30, mockOffset: { lat: -0.022, lon: -0.01 }, verified: true },
-        { id: 5, name: "Amit Sharma", profession: "AC Technician", rating: 4.7, price: 45, mockOffset: { lat: 0.008, lon: -0.025 }, verified: true },
-        { id: 6, name: "Suresh Patel", profession: "Cleaner", rating: 4.3, price: 25, mockOffset: { lat: 0.050, lon: 0.030 }, verified: true },
-        { id: 7, name: "David Lee", profession: "Mechanic", rating: 4.8, price: 55, mockOffset: { lat: -0.040, lon: 0.015 }, verified: true },
-        { id: 8, name: "Priya Singh", profession: "Gardener", rating: 4.4, price: 20, mockOffset: { lat: 0.003, lon: 0.004 }, verified: true },
-        { id: 9, name: "Imran Khan", profession: "Appliance Repair", rating: 4.6, price: 35, mockOffset: { lat: -0.018, lon: -0.030 }, verified: true },
-        { id: 10, name: "Neha Gupta", profession: "Pest Control", rating: 4.5, price: 40, mockOffset: { lat: 0.025, lon: -0.005 }, verified: true },
-      ]);
-      setLoading(false);
-    }, 800);
-  }, []);
-
-  // 🔍 Filter + Sort
-  const filteredWorkers = useMemo(() => {
-    let result = workers.map((w) => {
-      if (!coords) return { ...w, distanceKm: null };
-      const workerLat = coords.latitude + w.mockOffset.lat;
-      const workerLon = coords.longitude + w.mockOffset.lon;
-      return {
-        ...w,
-        distanceKm: getDistanceKm(coords.latitude, coords.longitude, workerLat, workerLon),
-      };
-    });
-
-    result = result.filter((w) => {
-      const q = searchQuery.toLowerCase();
-      const matchesSearch = w.name.toLowerCase().includes(q) || w.profession.toLowerCase().includes(q);
-      const matchesCategory = categoryFilter === "All" || w.profession === categoryFilter;
-      return matchesSearch && matchesCategory;
-    });
-
-    if (sortBy === "distance") {
-      result.sort((a, b) => (a.distanceKm || 999) - (b.distanceKm || 999));
-    } else if (sortBy === "rating") {
-      result.sort((a, b) => b.rating - a.rating);
-    } else if (sortBy === "price") {
-      result.sort((a, b) => a.price - b.price);
-    }
-
-    return result;
-  }, [workers, coords, searchQuery, categoryFilter, sortBy]);
-
-  return (
-    <div className="max-w-7xl mx-auto px-4 py-12">
-      {/* Header */}
-      <div className="text-center mb-10">
-        <h1 className="text-4xl font-bold text-gray-900">
-          Find Reliable Services Near You
-        </h1>
-        <p className="text-gray-500 mt-2">
-          {locationStatus === "success"
-            ? "Showing nearby professionals"
-            : locationStatus === "loading"
-            ? "Detecting your location..."
-            : "Enable location for better results"}
-        </p>
-      </div>
-
-      {/* Filters */}
-      <div className="mb-10 space-y-6">
-        <div className="flex flex-col sm:flex-row gap-4 max-w-3xl mx-auto">
-          <div className="relative flex-1">
-            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400">
-              🔍
-            </span>
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search by name or service..."
-              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-blue-500 shadow-sm transition"
-            />
-          </div>
-          {searchQuery && (
-            <button
-              onClick={() => setSearchQuery('')}
-              className="px-6 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-xl font-medium transition"
-            >
-              Clear
-            </button>
-          )}
-        </div>
-
-        <div className="flex flex-wrap justify-center gap-2">
-          {categories.map((cat) => (
-            <button
-              key={cat}
-              onClick={() => setCategoryFilter(cat)}
-              className={`px-5 py-2 rounded-full text-sm font-semibold transition-all duration-200 ${
-                categoryFilter === cat
-                  ? 'bg-blue-600 text-white shadow-lg scale-105'
-                  : 'bg-white text-gray-600 border border-gray-200 hover:border-blue-400 hover:text-blue-600 shadow-sm'
-              }`}
-            >
-              {cat !== "All" && iconMap[cat] && <span className="mr-2">{iconMap[cat]}</span>}
-              {cat}
-            </button>
-          ))}
-        </div>
-
-        <div className="flex justify-center gap-4">
-          {[
-            { id: 'distance', label: '📍 Nearest', icon: '📍' },
-            { id: 'rating', label: '⭐ Top Rated', icon: '⭐' },
-            { id: 'price', label: '💰 Lowest Price', icon: '💰' }
-          ].map((type) => (
-            <button
-              key={type.id}
-              onClick={() => setSortBy(type.id)}
-              className={`px-4 py-2 rounded-lg border transition ${
-                sortBy === type.id ? "bg-gray-900 text-white border-gray-900" : "bg-white text-gray-600 border-gray-200 hover:border-gray-400"
-              }`}
-            >
-              {type.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Content */}
-      {loading ? (
-        <LoadingSpinner />
-      ) : error ? (
-        <div className="text-center py-20 text-red-600 font-medium">{error}</div>
-      ) : filteredWorkers.length === 0 ? (
-        <div className="text-center py-20 bg-gray-50 rounded-3xl border-2 border-dashed border-gray-200">
-          <div className="text-6xl mb-4">🔦</div>
-          <h3 className="text-2xl font-bold text-gray-900 mb-2">No workers found</h3>
-          <p className="text-gray-500 mb-8 max-w-md mx-auto">Try broadening your filters.</p>
-          <button
-            onClick={() => {
-              setSearchQuery('');
-              setCategoryFilter('All');
-            }}
-            className="px-8 py-3 bg-blue-600 hover:bg-blue-700 text-white font-bold rounded-xl shadow-lg transition"
-          >
-            Reset All Filters
-          </button>
-        </div>
-      ) : (
-        <>
-          <p className="text-sm text-gray-500 mb-6 font-medium">
-            Showing {filteredWorkers.length} professionals found
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {filteredWorkers.map((worker) => (
-              <div
-                key={worker.id}
-                className="group bg-white rounded-2xl shadow-sm hover:shadow-2xl border border-gray-100 hover:border-blue-100 transition-all duration-300 overflow-hidden flex flex-col"
-              >
-                <div className="p-8 flex-1">
-                  <div className="flex items-start justify-between mb-6">
-                    <div className="w-16 h-16 bg-blue-50 text-blue-600 rounded-2xl flex items-center justify-center text-3xl shadow-inner group-hover:bg-blue-600 group-hover:text-white transition-colors duration-300">
-                      {iconMap[worker.profession] || '👷'}
-                    </div>
-                    {worker.verified && (
-                      <span className="bg-green-50 text-green-700 text-xs px-3 py-1.5 rounded-full font-bold flex items-center gap-1">
-                        <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></span>
-                        Verified
-                      </span>
-                    )}
-                  </div>
-                  <h3 className="text-2xl font-bold text-gray-900 mb-1 group-hover:text-blue-600 transition-colors">
-                    {worker.name}
-                  </h3>
-                  <p className="text-blue-600 font-bold mb-4">{worker.profession}</p>
-                  <div className="flex items-center gap-4 text-sm text-gray-600 mb-6 bg-gray-50 p-3 rounded-lg">
-                    <div className="flex items-center gap-1">
-                      <span className="text-yellow-400">★</span>
-                      <span className="font-bold text-gray-900">{worker.rating}</span>
-                    </div>
-                    <div className="w-px h-4 bg-gray-300"></div>
-                    <div className="font-bold text-gray-900">${worker.price}/hr</div>
-                    {worker.distanceKm && (
-                      <>
-                        <div className="w-px h-4 bg-gray-300"></div>
-                        <div className="font-bold text-gray-900">📍 {formatDistance(worker.distanceKm)}</div>
-                      </>
-                    )}
-                  </div>
-                </div>
                 <div className="p-8 pt-0">
                   <Link
                     to={`/worker/${worker.id}`}
                     onClick={() => handleRecentlyViewed(worker)}
-                    className="block w-full rounded-xl bg-gray-900 py-4 text-center font-bold text-white transition-all duration-300 hover:bg-blue-600"
+                    className="block w-full rounded-xl bg-slate-900 py-4 text-center font-bold text-white transition hover:bg-blue-600"
                   >
                     View Profile and Book
                   </Link>

--- a/client/src/pages/WorkerProfile.jsx
+++ b/client/src/pages/WorkerProfile.jsx
@@ -8,6 +8,7 @@ import {
   Briefcase,
   Phone,
   MessageCircle,
+  CalendarCheck,
 } from "lucide-react";
 
 import BookingConfirmationModal from "../components/BookingConfirmationModal";
@@ -24,6 +25,32 @@ const WORKERS = {
     location: "New York, USA",
     completedJobs: 240,
     bio: "Experienced electrician with 10+ years of expertise in residential and commercial projects.",
+    portfolio: [
+      {
+        id: 1,
+        image: "https://images.unsplash.com/photo-1621905251189-08b45d6a269e?w=400&h=250&fit=crop",
+        description: "Full apartment rewiring with safety inspection",
+        completionDate: "March 2025",
+        customerRating: 4.9,
+        review: "Excellent work, very professional and clean.",
+      },
+      {
+        id: 2,
+        image: "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=400&h=250&fit=crop",
+        description: "Installed new electrical panel and circuit breakers",
+        completionDate: "January 2025",
+        customerRating: 4.8,
+        review: "Quick and efficient, highly recommend.",
+      },
+      {
+        id: 3,
+        image: "https://images.unsplash.com/photo-1504328345606-18bbc8c9d7d1?w=400&h=250&fit=crop",
+        description: "Outdoor lighting setup for residential garden",
+        completionDate: "November 2024",
+        customerRating: 5.0,
+        review: "Transformed our garden, amazing attention to detail.",
+      },
+    ],
   },
   2: {
     id: 2,
@@ -35,6 +62,32 @@ const WORKERS = {
     location: "California, USA",
     completedJobs: 310,
     bio: "Licensed plumber with extensive expertise in leak fixing and pipeline installation.",
+    portfolio: [
+      {
+        id: 1,
+        image: "https://images.unsplash.com/photo-1607472586893-edb57bdc0e39?w=400&h=250&fit=crop",
+        description: "Full bathroom pipeline replacement and waterproofing",
+        completionDate: "April 2025",
+        customerRating: 5.0,
+        review: "No leaks at all, superb finish and very tidy work.",
+      },
+      {
+        id: 2,
+        image: "https://images.unsplash.com/photo-1585771724684-38269d6639fd?w=400&h=250&fit=crop",
+        description: "Kitchen sink installation and drain unclogging",
+        completionDate: "February 2025",
+        customerRating: 4.9,
+        review: "Fast response and clean job, would hire again.",
+      },
+      {
+        id: 3,
+        image: "https://images.unsplash.com/photo-1504148455328-c376907d081c?w=400&h=250&fit=crop",
+        description: "Water heater installation for a 3-bedroom home",
+        completionDate: "December 2024",
+        customerRating: 4.8,
+        review: "Professional and straightforward, great value.",
+      },
+    ],
   },
   3: {
     id: 3,
@@ -46,6 +99,32 @@ const WORKERS = {
     location: "Texas, USA",
     completedJobs: 180,
     bio: "Expert carpenter specializing in custom furniture and interior woodwork.",
+    portfolio: [
+      {
+        id: 1,
+        image: "https://images.unsplash.com/photo-1533090481720-856c6e3c1fdc?w=400&h=250&fit=crop",
+        description: "Custom built-in bookshelf for a home library",
+        completionDate: "April 2025",
+        customerRating: 4.7,
+        review: "Beautiful craftsmanship, exactly what I envisioned.",
+      },
+      {
+        id: 2,
+        image: "https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=400&h=250&fit=crop",
+        description: "Living room wooden furniture set — sofa frame and table",
+        completionDate: "January 2025",
+        customerRating: 4.5,
+        review: "Solid build quality, very happy with the result.",
+      },
+      {
+        id: 3,
+        image: "https://images.unsplash.com/photo-1567016376408-0226e4d0c1ea?w=400&h=250&fit=crop",
+        description: "Bedroom wardrobe with sliding doors and interior shelving",
+        completionDate: "October 2024",
+        customerRating: 4.6,
+        review: "Fits perfectly and looks amazing, great attention to detail.",
+      },
+    ],
   },
 };
 
@@ -161,26 +240,16 @@ const WorkerProfile = () => {
         <div className="lg:col-span-1">
           <div className="bg-white rounded-3xl shadow-sm border border-gray-100 p-6 sticky top-6">
 
-            {/* Avatar */}
+           {/* Avatar */}
             <div className="flex flex-col items-center text-center">
               <div className="w-28 h-28 rounded-full bg-blue-100 flex items-center justify-center text-4xl font-bold text-blue-700">
                 {worker.name.charAt(0)}
               </div>
-
-              <h1 className="text-2xl font-bold mt-4">
-                {worker.name}
-              </h1>
-
-              <p className="text-blue-600 font-medium">
-                {worker.profession}
-              </p>
-
-              {/* Rating */}
+              <h1 className="text-2xl font-bold mt-4">{worker.name}</h1>
+              <p className="text-blue-600 font-medium">{worker.profession}</p>
               <div className="flex items-center gap-1 mt-3 bg-yellow-50 px-3 py-1 rounded-full">
                 <Star size={16} className="fill-yellow-400 text-yellow-400" />
-                <span className="font-semibold">
-                  {worker.rating}
-                </span>
+                <span className="font-semibold">{worker.rating}</span>
               </div>
             </div>
 
@@ -320,6 +389,60 @@ const WorkerProfile = () => {
               ))}
             </div>
           </div>
+
+            {/* PORTFOLIO / PREVIOUS WORKS SECTION */}
+          {worker.portfolio && worker.portfolio.length > 0 && (
+            <div className="bg-white rounded-3xl shadow-sm border border-gray-100 p-8">
+              <h2 className="text-2xl font-bold mb-2">Previous Works</h2>
+              <p className="text-gray-500 mb-6">
+                A snapshot of completed projects by this professional.
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {worker.portfolio.map((item) => (
+                  <div
+                    key={item.id}
+                    className="rounded-2xl border border-gray-100 overflow-hidden hover:shadow-md transition group"
+                  >
+                    {/* Image */}
+                    <div className="relative h-44 overflow-hidden bg-gray-100">
+                      <img
+                        src={item.image}
+                        alt={item.description}
+                        className="w-full h-full object-cover group-hover:scale-105 transition duration-300"
+                      />
+                    </div>
+ 
+                    {/* Details */}
+                    <div className="p-5">
+                      <p className="font-semibold text-gray-900 text-sm leading-snug mb-2">
+                        {item.description}
+                      </p>
+ 
+                      {/* Date */}
+                      <div className="flex items-center gap-1.5 text-xs text-gray-400 mb-3">
+                        <CalendarCheck size={13} />
+                        <span>{item.completionDate}</span>
+                      </div>
+ 
+                      {/* Rating */}
+                      <div className="flex items-center gap-1 mb-2">
+                        <Star size={13} className="fill-yellow-400 text-yellow-400" />
+                        <span className="text-sm font-bold text-gray-800">
+                          {item.customerRating}
+                        </span>
+                      </div>
+ 
+                      {/* Review */}
+                      <p className="text-xs text-gray-500 italic leading-relaxed">
+                        "{item.review}"
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
 
           {/* Availability */}
           <div className="bg-gradient-to-r from-blue-600 to-indigo-600 rounded-3xl p-8 text-white">


### PR DESCRIPTION
## Summary
Adds a **Previous Works / Portfolio** section to the `WorkerProfile` page as requested in issue #189. Users can now view completed projects by a worker before making a booking decision.

Closes #189

---

## Changes Made

### `src/pages/WorkerProfile.jsx`
- Added `portfolio` array inside each worker object in `WORKERS` — every worker now has their own unique set of completed projects
- Added `CalendarCheck` to lucide-react imports
- Added the **Previous Works** section between Customer Reviews and the Availability CTA
- Section renders conditionally — hidden automatically if a worker has no portfolio entries

---

## What the Portfolio Section Includes
- Image of the completed work
- Work description
- Completion date
- Customer rating
- Customer review quote

---

## Screenshot
<img width="1920" height="3057" alt="image" src="https://github.com/user-attachments/assets/dbfcf566-1b2e-4ab6-a3f1-5444b1de1c1e" />


---

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

---

## Notes
- Portfolio data is currently mock data — each worker has 3 unique entries with profession-relevant images
- When a real backend is connected, the `portfolio` field can be fetched per worker and dropped in without any UI changes needed