### PR TITLE
fix: add vercel rewrite rule for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Description
Added a `vercel.json` rewrite configuration to properly handle SPA routing on Vercel deployments.

## Changes Made
- Added `vercel.json`
- Configured rewrite rule to redirect all routes to `index.html`
- Fixed refresh/direct URL access issues on deployed frontend

## Issue
Closes #166