### PR TITLE
fix: unify Join as a Pro navigation

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -132,7 +132,7 @@ const Footer = () => {
             </li>
 
             <li>
-              <Link to="/register" className={linkClass("/register")}>
+              <Link to="/worker-register" className={linkClass("/worker-register")}>
                 <FaArrowRight className="text-xs" />
                 Join as a Pro
               </Link>


### PR DESCRIPTION
##  Description
Fixed inconsistent navigation behavior for the "Join as a Pro" CTA across the application.

##  Related Issue
Closes #168

##  Changes Made
- Updated footer "Join as a Pro" link
- Unified CTA navigation behavior
- Ensured both navbar and footer redirect to the same onboarding page

##  Checklist
- [x] Code runs locally
- [x] No console errors
- [x] Properly tested changes
- [x] Linked the issue