### PR TITLE
fix: resolve inconsistent localStorage token keys causing 401 errors (#252)

### DIFF
--- a/client/src/pages/WorkerLogin.jsx
+++ b/client/src/pages/WorkerLogin.jsx
@@ -142,21 +142,18 @@ const WorkerLogin = () => {
       const response = 
         await workerLogin(formData);
 
-      // STORE TOKEN
-      if (response?.token) {
+      // STORE SESSION under the canonical key used by apiClient & AuthContext
+      if (response?.token && response?.worker) {
 
         localStorage.setItem(
-          "workerToken",
-          response.token
-        );
-      }
-
-      // STORE WORKER DATA
-      if (response?.worker) {
-
-        localStorage.setItem(
-          "workerData",
-          JSON.stringify(response.worker)
+          "fixnearby_user",
+          JSON.stringify({
+            _id: response.worker._id,
+            name: response.worker.name,
+            email: response.worker.email,
+            phone: response.worker.phone,
+            token: response.token,
+          })
         );
       }
 

--- a/client/src/services/availabilityService.js
+++ b/client/src/services/availabilityService.js
@@ -1,23 +1,16 @@
-import axios from 'axios';
+import api from './apiClient';
 
-const getAuthHeaders = () => {
-  const token = localStorage.getItem('token');
-  if (!token) throw new Error('Not authenticated');
-  return { Authorization: `Bearer ${token}` };
-};
-
-// Worker updates their status
+// Worker updates their status (requires auth via apiClient interceptor)
 export const updateAvailabilityStatus = async (status) => {
-  const res = await axios.put(
+  const res = await api.put(
     '/api/availability/status',
-    { availabilityStatus: status },
-    { headers: getAuthHeaders() }
+    { availabilityStatus: status }
   );
   return res.data;
 };
 
-// Fetch a worker's status
+// Fetch a worker's status (public — no auth required)
 export const getWorkerStatus = async (workerId) => {
-  const res = await axios.get(`/api/availability/status/${workerId}`);
+  const res = await api.get(`/api/availability/status/${workerId}`);
   return res.data;
-};
+};

--- a/client/src/services/favoriteService.js
+++ b/client/src/services/favoriteService.js
@@ -1,26 +1,15 @@
 // client/src/services/favoriteService.js
 
-import axios from "axios";
+import api from "./apiClient";
 
 const BASE_URL = "/api/favorites";
-
-// Helper: get auth token from localStorage
-const getAuthHeaders = () => {
-  const token = localStorage.getItem("token");
-  if (!token) throw new Error("User not authenticated");
-  return { Authorization: `Bearer ${token}` };
-};
 
 /**
  * Add a worker to favorites
  * @param {string} workerId
  */
 export const addFavorite = async (workerId) => {
-  const response = await axios.post(
-    `${BASE_URL}/${workerId}`,
-    {},
-    { headers: getAuthHeaders() }
-  );
+  const response = await api.post(`${BASE_URL}/${workerId}`, {});
   return response.data;
 };
 
@@ -29,9 +18,7 @@ export const addFavorite = async (workerId) => {
  * @param {string} workerId
  */
 export const removeFavorite = async (workerId) => {
-  const response = await axios.delete(`${BASE_URL}/${workerId}`, {
-    headers: getAuthHeaders(),
-  });
+  const response = await api.delete(`${BASE_URL}/${workerId}`);
   return response.data;
 };
 
@@ -52,9 +39,7 @@ export const toggleFavorite = async (workerId, isCurrentlyBookmarked) => {
  * Fetch all saved/favorite workers for logged-in user
  */
 export const getFavorites = async () => {
-  const response = await axios.get(BASE_URL, {
-    headers: getAuthHeaders(),
-  });
+  const response = await api.get(BASE_URL);
   return response.data; // Array of { _id, worker: {...}, createdAt }
 };
 


### PR DESCRIPTION
## fix: resolve inconsistent localStorage token keys causing 401 errors (#252)

### Summary

Authentication tokens were stored and retrieved under three different localStorage keys across the codebase, causing all authenticated API requests (saving favorites, updating availability) to fail with `401 Unauthorized`.

| Location | Key used | Problem |
|---|---|---|
| `AuthContext.jsx` + `apiClient.js` | `fixnearby_user` (JSON) | ✅ Correct — source of truth |
| `favoriteService.js` | `token` (raw string) | ❌ Always `null` |
| `availabilityService.js` | `token` (raw string) | ❌ Always `null` |
| `WorkerLogin.jsx` | `workerToken` + `workerData` | ❌ Orphaned — never read by apiClient |

---

### Changes

#### `client/src/services/favoriteService.js`
- Removed the local `getAuthHeaders()` helper that read from `localStorage.getItem("token")`
- Replaced raw `axios` import with the shared `api` client (`apiClient.js`)
- All four functions (`addFavorite`, `removeFavorite`, `getFavorites`, `isFavorited`) now go through the `apiClient` request interceptor, which correctly reads the Bearer token from `fixnearby_user`

#### `client/src/services/availabilityService.js`
- Same fix — removed broken `getAuthHeaders()` + raw `axios`
- `updateAvailabilityStatus` now uses `api.put(...)` (auth injected automatically)
- `getWorkerStatus` also migrated to `api.get(...)` for consistent `baseURL` usage

#### `client/src/pages/WorkerLogin.jsx`
- Replaced two separate `localStorage.setItem("workerToken", ...)` and `localStorage.setItem("workerData", ...)` calls with a single write to `fixnearby_user`
- The stored shape `{ _id, name, email, phone, token }` matches what `AuthContext.loadFromStorage()` and `apiClient`'s interceptor both expect

---

### Root Cause

`apiClient.js` already had a correct request interceptor reading from `fixnearby_user`. The services were written independently and never wired up to use it, each re-implementing a broken ad-hoc token lookup instead.

---

### Testing

- [ ] Log in as a standard user → click **Save** on a worker profile → verify request returns `200` (not `401`)
- [ ] Log in as a worker via `/worker/login` → toggle availability status → verify `PUT /api/availability/status` returns `200`
- [ ] Log out → confirm `fixnearby_user` is cleared from localStorage
- [ ] Hard-refresh after worker login → confirm session is restored correctly from `fixnearby_user`

---

### Related

Closes #252

