### PR TITLE
fix(auth): validate JWT_SECRET at startup to prevent silent authentication failure

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,15 @@ import authMiddleware from './middleware/authMiddleware.js';
 
 dotenv.config();
 
+// Fail fast if JWT_SECRET is missing. Without it, jwt.sign() in authController
+// throws at runtime on every login and register attempt, and older versions of
+// jsonwebtoken silently sign with an empty secret, making all accounts
+// impersonatable.
+if (!process.env.JWT_SECRET) {
+  console.error('FATAL: JWT_SECRET environment variable is not set. Server cannot start.');
+  process.exit(1);
+}
+
 const app = express();
 
 // Security Middleware


### PR DESCRIPTION
## Description

`server/server.js` calls `dotenv.config()` and immediately starts the Express app without checking whether `JWT_SECRET` is defined. `authController.js` calls `jwt.sign({ id }, process.env.JWT_SECRET, ...)` on every login and register request. When `JWT_SECRET` is absent from the environment, two failure modes exist:

- **Modern jsonwebtoken (>= 9):** throws `secretOrPrivateKey must have a value` at the moment of signing, crashing every auth request with an unhandled 500 and no indication of the root cause.
- **Older jsonwebtoken:** silently signs with an empty or undefined secret, producing tokens that any attacker can forge by signing with the same empty secret.

Neither failure is caught or surfaced clearly at startup.

## Root Cause

No environment validation runs before the server begins accepting connections. The missing variable is only discovered when the first login or register request arrives.

## Fix

Added an explicit check for `JWT_SECRET` immediately after `dotenv.config()`. If the variable is absent, the process logs a clear `FATAL` message and exits with a non-zero code, preventing the server from accepting connections in a broken state.

```js
if (!process.env.JWT_SECRET) {
  console.error('FATAL: JWT_SECRET environment variable is not set. Server cannot start.');
  process.exit(1);
}
```

## Related Issue

Closes #301

## Type of Change

- [x] Bug fix

## Changes Made

- `server/server.js`: added a fail-fast guard for `JWT_SECRET` immediately after `dotenv.config()`

## Screenshots or Demo

Not applicable (server-side startup guard).

## Testing Done

1. Remove `JWT_SECRET` from `.env`.
2. Start the server with `npm run dev`.
3. Observe the `FATAL` message in the console and confirm the process exits with code 1.
4. Set `JWT_SECRET` to a valid secret and restart. Confirm the server starts normally and login/register work as expected.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue

Could you please add the appropriate NSoC'26 label to this PR? It helps with tracking and scoring under NSoC 2026. Thank you!