### PR TITLE
fix(upload): add image-only allowlist and 5 MB size limit to Multer configuration

### DIFF
--- a/server/routes/issueRoutes.js
+++ b/server/routes/issueRoutes.js
@@ -17,17 +17,43 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const uploadDir = path.join(__dirname, '..', 'uploads');
 
+// Allowed image extensions and MIME types for issue thumbnails.
+const ALLOWED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp']);
+const ALLOWED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
     cb(null, uploadDir);
   },
   filename: function (req, file, cb) {
-    const ext = path.extname(file.originalname);
+    const ext = path.extname(file.originalname).toLowerCase();
     cb(null, `${Date.now()}-${Math.random().toString(36).substring(2,8)}${ext}`);
   }
 });
 
-const upload = multer({ storage });
+// Reject uploads whose extension or MIME type is not in the allowlist.
+// Checking both prevents bypasses where an attacker supplies a benign
+// extension with a dangerous MIME type (or vice versa).
+const fileFilter = (req, file, cb) => {
+  const ext = path.extname(file.originalname).toLowerCase();
+  if (!ALLOWED_EXTENSIONS.has(ext) || !ALLOWED_MIME_TYPES.has(file.mimetype)) {
+    return cb(new Error('Only image files (jpg, jpeg, png, gif, webp) are allowed.'), false);
+  }
+  cb(null, true);
+};
+
+const upload = multer({
+  storage,
+  fileFilter,
+  limits: {
+    fileSize: 5 * 1024 * 1024, // 5 MB per file
+  },
+});
 
 // GET /nearby
 router.get('/nearby', getNearbyIssues);


### PR DESCRIPTION
## Description

The Multer configuration for issue image uploads in `server/routes/issueRoutes.js` set no `fileFilter` and no `limits`. Any HTTP client could upload a file of any MIME type and any size. Because uploaded files are served from the static `/uploads` directory, this allowed:

- Upload of HTML, JavaScript, or executable files that could be used for stored XSS or phishing via direct URL access.
- Disk exhaustion through large file uploads with no size cap.

## Root Cause

`const upload = multer({ storage })` — the `fileFilter` and `limits` options were omitted entirely.

## Fix

`server/routes/issueRoutes.js`:

- Added `ALLOWED_EXTENSIONS` (`jpg`, `jpeg`, `png`, `gif`, `webp`) and `ALLOWED_MIME_TYPES` sets used as an allowlist in a `fileFilter`. Both extension and MIME type are validated to prevent bypasses where an attacker supplies a mismatched pair.
- Added `limits: { fileSize: 5 * 1024 * 1024 }` to cap uploads at 5 MB.
- Lowercased the stored extension to normalise `.JPG` / `.JPEG` variants.

## Related Issue

Closes #299

## Type of Change

- [x] Bug fix

## Changes Made

- `server/routes/issueRoutes.js`: added `ALLOWED_EXTENSIONS`, `ALLOWED_MIME_TYPES`, `fileFilter`, and `limits` to the Multer instance

## Screenshots or Demo

Not applicable.

## Testing Done

1. Attempt to upload a `.exe` file to `POST /api/issues` with an image field. Confirm the server rejects with a 400 and the error message "Only image files ... are allowed."
2. Attempt to upload a valid image larger than 5 MB. Confirm Multer rejects with a file size error.
3. Upload a valid JPEG or PNG under 5 MB. Confirm the issue is created and the thumbnail URL is returned correctly.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue

Could you please add the appropriate NSoC'26 label to this PR? It helps with tracking and scoring under NSoC 2026. Thank you!