### PR TITLE
fix: update CORS origin from localhost:3000 to localhost:5173

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ JWT_SECRET=your_jwt_secret_here
 
 # Frontend
 VITE_API_URL=http://localhost:5000/api
+CLIENT_URL=http://localhost:5173

--- a/server/server.js
+++ b/server/server.js
@@ -25,7 +25,7 @@ app.use(limiter);
 
 // CORS configuration
 app.use(cors({
-  origin: process.env.CLIENT_URL || 'http://localhost:3000',
+  origin: process.env.CLIENT_URL || 'http://localhost:5173',
   credentials: true
 }));
 


### PR DESCRIPTION
Fixes #247

## Changes Made

- Updated CORS origin fallback in `server/server.js` from `http://localhost:3000` to `http://localhost:5173`
- Added `CLIENT_URL=http://localhost:5173` to `server/.env`
- Added `CLIENT_URL=http://localhost:5173` to `.env.example`

## Problem

The backend CORS config was allowing requests from `http://localhost:3000` 
but the Vite frontend runs on `http://localhost:5173`, causing all API 
requests to be blocked by the browser.

## Solution

Changed the fallback origin to match the Vite dev server port and added 
`CLIENT_URL` as an environment variable so it can be configured for 
production deployments.

## Testing

- Started backend server on port 5000
- Started frontend on port 5173
- Confirmed no CORS errors in browser console
- Worker registration API call succeeds