### PR TITLE
Set default baseURL for API client

### DIFF
--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-    baseURL:`${import.meta.env.VITE_API_URL}`,
+   baseURL: import.meta.env.VITE_API_URL || "http://localhost:5000",
     headers:{
         "Content-Type":"application/json"
     },


### PR DESCRIPTION
### Summary

This PR improves the API client configuration by adding a fallback value for the application's base API URL when the `VITE_API_URL` environment variable is not defined.

### Changes Made

* Added a default API endpoint as a fallback for `baseURL`.
* Prevented API requests from failing due to missing environment configuration.
* Improved developer experience when running the project locally without a complete `.env` setup.

### Why This Change?

Currently, the API client relies entirely on the `VITE_API_URL` environment variable. If this variable is missing or incorrectly configured, Axios initializes with an invalid base URL, causing all API requests to fail.

By providing a sensible fallback value, the application becomes more resilient and easier to set up for new contributors while maintaining existing behavior when `VITE_API_URL` is properly configured.

### Impact

* Improves reliability during local development.
* Reduces setup-related errors for contributors.
* Maintains backward compatibility with existing deployments.
