### PR TITLE
Remove 'Explore Community' link

### DIFF
--- a/client/src/pages/Community.jsx
+++ b/client/src/pages/Community.jsx
@@ -365,12 +365,7 @@ const Community = () => {
               </p>
 
               <div className="mt-10 flex gap-4 flex-wrap">
-                <Link
-                  to="/community"
-                  className="bg-blue-600 hover:bg-blue-700 px-8 py-4 rounded-2xl font-bold transition"
-                >
-                  Explore Community
-                </Link>
+               
 
                 <Link
                   to="/services"


### PR DESCRIPTION
Removed 'Explore Community' link from the Community page.## Summary

This PR removes a self-referencing navigation link from the Community page.

## Changes Made

- Replaced the "Explore Community" link that points to `/community` while already on the Community page.
- Improved navigation flow by avoiding redundant route transitions.

## Why This Change?

The current button navigates users to the same page they are already viewing, providing no functional benefit and potentially causing confusion.

## Impact

- Cleaner user experience.
- More meaningful navigation behavior.
- No impact on existing functionality.

