### PR TITLE
fix(auth): normalize worker email to lowercase on login

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -248,9 +248,8 @@ export const registerWorker = async (req, res) => {
 export const loginWorker = async (req, res) => {
   try {
     const { email, password } = req.body;
-
-    const worker = await Worker.findOne({ email });
-
+const normalizedEmail = email?.trim().toLowerCase();
+const worker = await Worker.findOne({ email: normalizedEmail });
     if (
       worker &&
       (await worker.matchPassword(password))
@@ -597,4 +596,4 @@ export const logoutUser = async (req, res) => {
       message: "Server error during logout"
     });
   }
-};
+};


### PR DESCRIPTION
# Description

`loginWorker` was not normalizing the email to lowercase before the database lookup. This caused workers who registered with mixed-case emails to fail login when using lowercase. Added `email?.trim().toLowerCase()` before the `Worker.findOne()` call, consistent with how `loginUser` already works.

Fixes #533 

## Type of change : BUG FIX

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually via Postman:
1. Registered a worker with email `Worker@Example.com`
2. Attempted login with `worker@example.com`
3. Login now succeeds after the fix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Mobile responsive layout verified locally
- [ ] Accessibility standards (WCAG) considered and validated
- [x] SQL/NoSQL Injection vulnerabilities verified and prevented