### PR TITLE
fix: Navbar shows authenticated options before login

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -19,7 +19,7 @@ const WrenchIcon = () => (
 );
 
 const Navbar = () => {
-  const { isAuthenticated, user, logout } = useAuth();
+  const { isAuthenticated, user, logout, authLoading } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
@@ -95,7 +95,7 @@ const Navbar = () => {
             </a>
             <Link to="/services" className={desktopLinkCls('/services')}>{t("nav.services")}</Link>
             <LanguageToggle />
-            {isAuthenticated ? (
+            {(authLoading ? false : isAuthenticated) ? (
               <>
                 <Link to="/bookings" className={desktopLinkCls('/bookings')}>{t("nav.bookings")}</Link>
                 <div className="relative ml-1">
@@ -177,7 +177,7 @@ const Navbar = () => {
         <nav className="flex flex-col gap-1">
           <a href="/#how-it-works" onClick={() => setMenuOpen(false)} className={mobileLinkCls('/#how-it-works')}>{t("nav.howItWorks")}</a>
           <Link to="/services" onClick={() => setMenuOpen(false)} className={mobileLinkCls('/services')}>{t("nav.services")}</Link>
-          {isAuthenticated ? (
+          {(authLoading ? false : isAuthenticated) ? (
             <>
               <Link to="/bookings" onClick={() => setMenuOpen(false)} className={mobileLinkCls('/bookings')}>{t("nav.bookings")}</Link>
               <Link to="/profile" onClick={() => setMenuOpen(false)} className={mobileLinkCls('/profile')}>{t("nav.profile")}</Link>

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,13 +1,9 @@
-import { createContext, useContext, useState, useCallback } from 'react';
+import { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import api from '../services/apiClient';
 
 /**
  * AuthContext
- * Provides { user, token, login, logout, isAuthenticated } to the entire tree.
- *
- * user  – { _id, name, email } or null
- * token – JWT string or null
- * login(userData) – persists user + token to state and localStorage
- * logout()        – clears state and localStorage
+ * Provides { user, token, login, logout, isAuthenticated, authLoading } to the entire tree.
  */
 const AuthContext = createContext(null);
 
@@ -22,29 +18,112 @@ const loadFromStorage = () => {
   }
 };
 
+const normalizeFromUserProfile = (profile, token) => {
+  if (!profile) return null;
+  return {
+    _id: profile._id,
+    name: profile.name,
+    email: profile.email,
+    phone: profile.phone,
+    token,
+  };
+};
+
+const normalizeFromWorkerProfile = (workerProfile, token) => {
+  // server returns { success: true, worker: req.worker }
+  const w = workerProfile?.worker;
+  if (!w) return null;
+  return {
+    _id: w.id || w._id,
+    name: w.name,
+    email: w.email,
+    phone: w.phone,
+    token,
+  };
+};
+
 export const AuthProvider = ({ children }) => {
   const [authData, setAuthData] = useState(() => loadFromStorage());
+  const [authLoading, setAuthLoading] = useState(true);
 
   const login = useCallback((userData) => {
-    // userData = { _id, name, email, token }
+    // userData = { _id, name, email, token, phone? }
     localStorage.setItem(STORAGE_KEY, JSON.stringify(userData));
     setAuthData(userData);
+    setAuthLoading(false);
   }, []);
 
   const logout = useCallback(() => {
     localStorage.removeItem(STORAGE_KEY);
     setAuthData(null);
+    setAuthLoading(false);
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const validateToken = async () => {
+      const stored = loadFromStorage();
+      const token = stored?.token;
+
+      // No token: auth is definitely not authenticated.
+      if (!token) {
+        if (!cancelled) {
+          setAuthData(null);
+          setAuthLoading(false);
+        }
+        return;
+      }
+
+      try {
+        // 1) Validate as a regular user
+        const userProfile = await api.get('/auth/profile');
+        if (cancelled) return;
+
+        const nextAuth = normalizeFromUserProfile(userProfile.data, token);
+        if (!nextAuth) throw new Error('Invalid user profile shape');
+
+        setAuthData(nextAuth);
+        setAuthLoading(false);
+        return;
+      } catch (e) {
+        // 2) Try as a worker
+        try {
+          const workerProfile = await api.get('/auth/worker/profile');
+          if (cancelled) return;
+
+          const nextAuth = normalizeFromWorkerProfile(workerProfile.data, token);
+          if (!nextAuth) throw new Error('Invalid worker profile shape');
+
+          setAuthData(nextAuth);
+          setAuthLoading(false);
+        } catch {
+          // Token exists but is invalid/expired/blacklisted.
+          if (!cancelled) logout();
+        }
+      }
+    };
+
+    validateToken();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [logout]);
+
   const value = {
-    user: authData ? {
-      _id: authData._id,
-      name: authData.name,
-      email: authData.email,
-      phone: authData.phone,
-    } : null,
+    user: authData
+      ? {
+          _id: authData._id,
+          name: authData.name,
+          email: authData.email,
+          phone: authData.phone,
+        }
+      : null,
     token: authData?.token ?? null,
-    isAuthenticated: !!authData?.token,
+    // Important: do not treat localStorage token as truth until validation completes.
+    isAuthenticated: !authLoading && !!authData?.token,
+    authLoading,
     login,
     logout,
   };
@@ -61,3 +140,4 @@ export const useAuth = () => {
 };
 
 export default AuthContext;
+


### PR DESCRIPTION
Fixed Navbar showing authenticated options before login by validating the stored JWT on app start.

Changes:

Updated client/src/context/AuthContext.jsx:
Added authLoading state.
On mount, if a token exists in localStorage, it now validates it against the backend:
GET /auth/profile (user)
fallback GET /auth/worker/profile (worker)
If both validations fail, it clears storage via logout().
isAuthenticated is now false until validation finishes.
Updated client/src/components/Navbar.jsx:
Authenticated links render only when authLoading is complete (authLoading ? false : isAuthenticated).


closes #79