### PR TITLE
fix: handle JsonWebTokenError and TokenExpiredError in global error handler

### DIFF
--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -23,6 +23,17 @@ const errorHandler = (err, req, res, next) => {
     error = { message, statusCode: 400 };
   }
 
+  // JWT Errors
+  if (err.name === 'JsonWebTokenError') {
+    const message = 'Not authorized, token validation failed';
+    error = { message, statusCode: 401 };
+  }
+
+  if (err.name === 'TokenExpiredError') {
+    const message = 'Not authorized, token has expired';
+    error = { message, statusCode: 401 };
+  }
+
   const statusCode = error.statusCode || 500;
   const responseMessage = (statusCode === 500 && process.env.NODE_ENV === 'production')
     ? 'Internal Server Error'

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -833,7 +833,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",


### PR DESCRIPTION
# Related Issue
Closes issue: #580

# Summary
Updates the global Express error handler to map JsonWebToken errors to clean HTTP 401 statuses.

# Changes Made
- Added checks for `JsonWebTokenError` and `TokenExpiredError` in `server/middleware/errorHandler.js`.

# Testing
- Triggered malformed token requests and confirmed status 401 was returned.

# Impact
Improves authentication exception handling and API response mapping.

# Checklist
- [x] Code follows repository style guidelines
- [x] Tested changes locally
- [x] No merge conflicts with master
