### PR TITLE
fix(auth): add password strength validation to worker registration

### DIFF
--- a/server/controllers/workerController.js
+++ b/server/controllers/workerController.js
@@ -2,6 +2,7 @@ import jwt from "jsonwebtoken";
 import Worker from "../models/Worker.js";
 import mongoose from "mongoose";
 import { calculateKarmaScores } from "../utils/karmaScheduler.js";
+import { validatePassword } from "../utils/validatePassword.js";
 
 const generateToken = (id) => {
   return jwt.sign(
@@ -52,6 +53,14 @@ export const registerWorker = async (req, res) => {
             message: "Invalid email format",
           });
         }
+
+      const passwordCheck = validatePassword(password);
+      if (!passwordCheck.valid) {
+        return res.status(400).json({
+          success: false,
+          message: passwordCheck.message,
+        });
+      }
 
       const existingWorker =
         await Worker.findOne({

--- a/server/utils/validatePassword.js
+++ b/server/utils/validatePassword.js
@@ -1,0 +1,20 @@
+const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/;
+const MIN_LENGTH = 6;
+
+export const validatePassword = (password) => {
+  if (!password || password.length < MIN_LENGTH) {
+    return {
+      valid: false,
+      message: `Password must be at least ${MIN_LENGTH} characters`,
+    };
+  }
+
+  if (!PASSWORD_REGEX.test(password)) {
+    return {
+      valid: false,
+      message: "Password must contain uppercase, lowercase and a number",
+    };
+  }
+
+  return { valid: true, message: null };
+};


### PR DESCRIPTION
## Summary

Worker registration accepted any password without strength validation, while user registration enforced complexity rules. This fix applies the same requirements to worker accounts.

Closes #521

## Changes

| File | What |
|------|------|
| `server/utils/validatePassword.js` | NEW - Shared password validation utility (min 6 chars, uppercase + lowercase + number) |
| `server/controllers/workerController.js` | Added `validatePassword()` call in `registerWorker` after email validation |

## How It Works

The `validatePassword()` utility returns `{ valid, message }`. If the password is invalid, the registration endpoint returns 400 with the specific failure reason. Rules match `authController.js` exactly:

- Minimum 6 characters
- At least one uppercase letter
- At least one lowercase letter
- At least one number

## Testing

```bash
# Weak password (rejected)
curl -X POST http://localhost:5000/api/worker/register \
  -H "Content-Type: application/json" \
  -d '{"name":"Test","email":"t@t.com","password":"abc","category":"Plumber","experience":"2y","location":"Mumbai","contact":"9999","bio":"hi"}'
# -> 400: "Password must be at least 6 characters"

# No uppercase (rejected)
curl -X POST ... -d '{"...","password":"abcdef1"}'
# -> 400: "Password must contain uppercase, lowercase and a number"

# Valid password (accepted)
curl -X POST ... -d '{"...","password":"Test123"}'
# -> 201: Worker registered
```

## Checklist

- [x] Worker registration rejects weak passwords with a clear error message
- [x] Validation rules match user registration (min 6 chars, uppercase, lowercase, number)
- [x] Existing workers with weak passwords not affected (registration-only check)
- [x] Shared utility avoids code duplication
- [x] Follows existing code style (Express.js, ES module imports)
