### PR TITLE
fix(client): normalize api base paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,21 +4,10 @@
 PORT=5000
 MONGODB_URI=mongodb://localhost:27017/FixNearby
 JWT_SECRET=your_jwt_secret_here
-
-
-BREVO_API_KEY = brevo_api_key_here
+CLIENT_URL=http://localhost:5173
+BREVO_API_KEY=brevo_api_key_here
 BREVO_SENDER_NAME=sender_side_name_here
 BREVO_SENDER_EMAIL=sender_side_email_here
 
 # Frontend
 VITE_API_URL=http://localhost:5000/api
-# Environment Variables
-
-# Backend
-PORT=5000
-MONGODB_URI=mongodb://localhost:27017/FixNearby
-JWT_SECRET=your_jwt_secret_here
-
-# Frontend
-VITE_API_URL=http://localhost:5000/api
-CLIENT_URL=http://localhost:5173

--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -1,7 +1,12 @@
 import axios from "axios";
 
+const normalizeApiBaseURL = (value) => {
+  const baseURL = (value || "http://localhost:5000/api").replace(/\/+$/, "");
+  return baseURL.endsWith("/api") ? baseURL : `${baseURL}/api`;
+};
+
 const api = axios.create({
-   baseURL: import.meta.env.VITE_API_URL || "http://localhost:5000",
+   baseURL: normalizeApiBaseURL(import.meta.env.VITE_API_URL),
     headers:{
         "Content-Type":"application/json"
     },
@@ -11,6 +16,10 @@ const api = axios.create({
 // Request interceptor to automatically add the Authorization header
 api.interceptors.request.use(
   (config) => {
+    if (typeof config.url === "string") {
+      config.url = config.url.replace(/^\/api(?=\/)/, "");
+    }
+
     try {
       const raw = localStorage.getItem("fixnearby_user");
       if (raw) {

--- a/client/src/services/availabilityService.js
+++ b/client/src/services/availabilityService.js
@@ -3,7 +3,7 @@ import api from './apiClient';
 // Worker updates their status (requires auth via apiClient interceptor)
 export const updateAvailabilityStatus = async (status) => {
   const res = await api.put(
-    '/api/availability/status',
+    '/availability/status',
     { availabilityStatus: status }
   );
   return res.data;
@@ -11,7 +11,7 @@ export const updateAvailabilityStatus = async (status) => {
 
 // Fetch a worker's status (public — no auth required)
 export const getWorkerStatus = async (workerId) => {
-  const res = await api.get(`/api/availability/status/${workerId}`);
+  const res = await api.get(`/availability/status/${workerId}`);
   return res.data;
 };
 
@@ -21,4 +21,4 @@ export const getWorkerAvailability = async (workerId, dateRange = 7) => {
     params: { dateRange }
   });
   return res.data;
-};
+};

--- a/client/src/services/estimateService.js
+++ b/client/src/services/estimateService.js
@@ -1,6 +1,6 @@
 import api from "./apiClient";
 
-const BASE_URL = "/api/estimates";
+const BASE_URL = "/estimates";
 
 /**
  * Preview estimate based on inputs

--- a/client/src/services/favoriteService.js
+++ b/client/src/services/favoriteService.js
@@ -2,7 +2,7 @@
 
 import api from "./apiClient";
 
-const BASE_URL = "/api/favorites";
+const BASE_URL = "/favorites";
 
 /**
  * Add a worker to favorites


### PR DESCRIPTION
# Related Issue
Closes #635 

# Summary
This PR fixes inconsistent API path construction in the client service layer. It prevents duplicated `/api/api/...` requests when the environment variable already points to the API root.

# Changes Made
- Normalize `VITE_API_URL` in the shared Axios client.
- Strip accidental `/api` prefixes from request URLs.
- Update favorite, estimate, and availability services to use API-relative paths.
- Clean duplicated root environment example entries.

# Testing
- Ran `npm run lint` in `client`.
- Ran `npm run build` in `client`.
- Ran `git diff --check`.

# Screenshots
Not applicable. This is a service-layer/configuration fix.

# Impact
Improves API reliability across local and deployed environments and reduces configuration-related request failures.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered