### PR TITLE
feat(workers): add availability status api

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -29,6 +29,49 @@ paths:
       responses:
         '200':
           description: Successful profile retrieval
+  /api/availability/status:
+    put:
+      summary: Update authenticated worker availability status
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - availabilityStatus
+              properties:
+                availabilityStatus:
+                  type: string
+                  enum:
+                    - available
+                    - busy
+                    - offline
+      responses:
+        '200':
+          description: Availability status updated successfully
+        '400':
+          description: Invalid availability status
+        '401':
+          description: Worker authentication is required
+  /api/availability/status/{workerId}:
+    get:
+      summary: Get a worker's public availability status
+      parameters:
+        - name: workerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Worker availability status returned successfully
+        '400':
+          description: Invalid worker ID
+        '404':
+          description: Worker not found
   /api/issues/nearby:
     get:
       summary: Get Nearby Issues

--- a/server/controllers/workerController.js
+++ b/server/controllers/workerController.js
@@ -6,6 +6,8 @@ import { validatePassword } from "../utils/validatePassword.js";
 import Booking from "../models/Booking.js";
 import Review from "../models/Review.js";
 
+const WORKER_AVAILABILITY_STATUSES = ["available", "busy", "offline"];
+
 const generateToken = (id) => {
   return jwt.sign(
     { id },
@@ -239,6 +241,86 @@ export const getWorkerProfile = async (req, res) => {
     success: true,
     worker: req.worker,
   });
+};
+
+export const updateWorkerAvailabilityStatus = async (req, res) => {
+  try {
+    const { availabilityStatus } = req.body;
+
+    if (!WORKER_AVAILABILITY_STATUSES.includes(availabilityStatus)) {
+      return res.status(400).json({
+        success: false,
+        message: "Availability status must be available, busy, or offline",
+      });
+    }
+
+    const worker = await Worker.findByIdAndUpdate(
+      req.worker._id,
+      {
+        availabilityStatus,
+        lastActive: new Date(),
+      },
+      {
+        new: true,
+        runValidators: true,
+      }
+    ).select("availabilityStatus lastActive");
+
+    if (!worker) {
+      return res.status(404).json({
+        success: false,
+        message: "Worker not found",
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      availabilityStatus: worker.availabilityStatus,
+      lastActive: worker.lastActive,
+    });
+  } catch (error) {
+    console.error("Error updating worker availability status:", error);
+    res.status(500).json({
+      success: false,
+      message: "Server error",
+    });
+  }
+};
+
+export const getWorkerAvailabilityStatus = async (req, res) => {
+  try {
+    const { workerId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(workerId)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid worker ID",
+      });
+    }
+
+    const worker = await Worker.findById(workerId)
+      .select("availabilityStatus lastActive")
+      .lean();
+
+    if (!worker) {
+      return res.status(404).json({
+        success: false,
+        message: "Worker not found",
+      });
+    }
+
+    res.status(200).json({
+      success: true,
+      availabilityStatus: worker.availabilityStatus,
+      lastActive: worker.lastActive,
+    });
+  } catch (error) {
+    console.error("Error fetching worker availability status:", error);
+    res.status(500).json({
+      success: false,
+      message: "Server error",
+    });
+  }
 };
 
 export const getNearbyWorkers = async (req, res) => {

--- a/server/routes/availabilityRoutes.js
+++ b/server/routes/availabilityRoutes.js
@@ -1,0 +1,13 @@
+import express from "express";
+import {
+  getWorkerAvailabilityStatus,
+  updateWorkerAvailabilityStatus,
+} from "../controllers/workerController.js";
+import { protectWorker } from "../middleware/authMiddleware.js";
+
+const router = express.Router();
+
+router.put("/status", protectWorker, updateWorkerAvailabilityStatus);
+router.get("/status/:workerId", getWorkerAvailabilityStatus);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,7 @@ import { startWorker } from './workers/notificationWorker.js';
 import { startBookingReminderScheduler } from './workers/bookingReminderWorker.js';
 import favoriteRoutes from './routes/favoriteRoutes.js';
 import estimateRoutes from './routes/estimateRoutes.js';
+import availabilityRoutes from './routes/availabilityRoutes.js';
 
 dotenv.config();
 
@@ -110,6 +111,7 @@ app.use('/api/reviews', reviewRoutes);
 app.use('/api/bookings', bookingRoutes);
 app.use('/api/favorites', favoriteRoutes);
 app.use('/api/estimates', estimateRoutes);
+app.use('/api/availability', availabilityRoutes);
 
 // Start Booking Expiry Check Scheduler
 startBookingExpiryScheduler();

--- a/server/tests/verifyAvailabilityStatusRoutes.js
+++ b/server/tests/verifyAvailabilityStatusRoutes.js
@@ -1,0 +1,27 @@
+import assert from "assert";
+import express from "express";
+import availabilityRoutes from "../routes/availabilityRoutes.js";
+
+const app = express();
+app.use(express.json());
+app.use("/api/availability", availabilityRoutes);
+
+const routeStack = app._router.stack
+  .flatMap((layer) => layer.handle?.stack || [])
+  .filter((layer) => layer.route)
+  .map((layer) => ({
+    path: layer.route.path,
+    methods: Object.keys(layer.route.methods),
+  }));
+
+assert(
+  routeStack.some((route) => route.path === "/status" && route.methods.includes("put")),
+  "Expected PUT /api/availability/status route to be registered"
+);
+
+assert(
+  routeStack.some((route) => route.path === "/status/:workerId" && route.methods.includes("get")),
+  "Expected GET /api/availability/status/:workerId route to be registered"
+);
+
+console.log("Availability status routes are registered.");


### PR DESCRIPTION
# Related Issue
Closes #639

# Summary
This PR adds backend support for worker availability status updates and public status reads. It completes the API contract already expected by the frontend availability UI.

# Changes Made
- Add `PUT /api/availability/status` for authenticated worker status updates.
- Add `GET /api/availability/status/:workerId` for public worker status reads.
- Validate allowed availability states: `available`, `busy`, and `offline`.
- Update Swagger documentation for the new endpoints.
- Add a lightweight route registration verification script.

# Testing
- Ran `node --check controllers/workerController.js`.
- Ran `node --check routes/availabilityRoutes.js`.
- Ran `node --check server.js`.
- Ran `node tests/verifyAvailabilityStatusRoutes.js`.
- Ran `npm run lint` in `client`.
- Ran `npm run build` in `client`.

# Screenshots
Not applicable. This is an API integration fix.

# Impact
Restores the worker availability update flow and keeps worker discovery data more accurate for users.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered