### PR TITLE
fix(favorites): replace blocking alerts with toasts

### DIFF
--- a/client/src/components/BookmarkButton.jsx
+++ b/client/src/components/BookmarkButton.jsx
@@ -2,11 +2,13 @@
 
 import { useState } from "react";
 import { toggleFavorite } from "../services/favoriteService";
+import useToast from "../hooks/useToast";
 
 const BookmarkButton = ({ workerId, initialBookmarked = false, onToggle }) => {
   const [bookmarked, setBookmarked] = useState(initialBookmarked);
   const [loading, setLoading] = useState(false);
   const [animating, setAnimating] = useState(false);
+  const { showToast } = useToast();
 
   const handleToggle = async (e) => {
     e.stopPropagation(); // prevent card click
@@ -21,7 +23,7 @@ const BookmarkButton = ({ workerId, initialBookmarked = false, onToggle }) => {
       if (onToggle) onToggle(workerId, !bookmarked);
     } catch (err) {
       console.error("Bookmark toggle failed:", err);
-      alert("Failed to update bookmark. Please login first.");
+      showToast("Failed to update bookmark. Please login first.", "error");
     } finally {
       setLoading(false);
       setTimeout(() => setAnimating(false), 400);

--- a/client/src/pages/SavedWorkers.jsx
+++ b/client/src/pages/SavedWorkers.jsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { getFavorites, removeFavorite } from "../services/favoriteService";
 import { useNavigate } from "react-router-dom";
+import useToast from "../hooks/useToast";
 
 // ────────────────────────────────────────────────────────
 //  Inline styles — no extra CSS file needed
@@ -267,6 +268,7 @@ const SavedWorkers = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
   useEffect(() => {
     const fetchFavorites = async () => {
@@ -292,7 +294,7 @@ const SavedWorkers = () => {
       await removeFavorite(workerId);
       setFavorites((prev) => prev.filter((fav) => fav.worker._id !== workerId));
     } catch (err) {
-      alert("Failed to remove. Try again.");
+      showToast("Failed to remove saved worker. Try again.", "error");
     }
   };
 

--- a/client/src/pages/Services.jsx
+++ b/client/src/pages/Services.jsx
@@ -23,6 +23,7 @@ import { useLocation } from "../context/LocationContext";
 import { getWorkerAvailability } from "../services/availabilityService";
 import { useAuth } from "../context/AuthContext";
 import { getFavorites, toggleFavorite } from "../services/favoriteService";
+import useToast from "../hooks/useToast";
 import { getEstimatorConfig } from "../utils/estimatorConfig";
 import EstimateWizard from "../components/EstimateWizard";
 import MapView from "../components/MapView";
@@ -292,6 +293,7 @@ const Services = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const { coords } = useLocation();
   const { isAuthenticated } = useAuth();
+  const { showToast } = useToast();
 
   const [searchQuery, setSearchQuery] = useState(
     searchParams.get("search") || ""
@@ -339,7 +341,7 @@ const Services = () => {
 
   const handleToggleFavorite = async (workerId) => {
     if (!isAuthenticated) {
-      alert("Please log in to save professionals to your favorites.");
+      showToast("Please log in to save professionals to your favorites.", "error");
       return;
     }
 
@@ -369,7 +371,7 @@ const Services = () => {
         }
         return copy;
       });
-      alert("Failed to update favorite. Please try again.");
+      showToast("Failed to update favorite. Please try again.", "error");
     }
   };
 

--- a/client/src/pages/WorkerProfile.jsx
+++ b/client/src/pages/WorkerProfile.jsx
@@ -29,6 +29,7 @@ import { createBooking } from "../services/bookingService";
 import { useAuth } from "../context/AuthContext";
 import { getWorkerAvailability } from "../services/availabilityService";
 import { getFavorites, toggleFavorite } from "../services/favoriteService";
+import useToast from "../hooks/useToast";
 
 /* ✅ Move data outside component */
 const WORKERS = {
@@ -259,6 +260,7 @@ const WorkerProfile = () => {
   const { id } = useParams();
   const navigate = useNavigate();
   const { isAuthenticated } = useAuth();
+  const { showToast } = useToast();
 
   const [activeTab, setActiveTab]          = useState("overview");
   const [showModal, setShowModal]           = useState(false);
@@ -360,7 +362,7 @@ const WorkerProfile = () => {
 
   const handleToggleFavorite = async () => {
     if (!isAuthenticated) {
-      alert("Please log in to save professionals to your favorites.");
+      showToast("Please log in to save professionals to your favorites.", "error");
       return;
     }
 
@@ -372,7 +374,7 @@ const WorkerProfile = () => {
     } catch (err) {
       console.error("Failed to toggle favorite:", err);
       setIsSaved(previousSaved);
-      alert("Failed to update favorite. Please try again.");
+      showToast("Failed to update favorite. Please try again.", "error");
     }
   };
 


### PR DESCRIPTION
# Related Issue
Closes #641

# Summary
This PR replaces blocking browser alerts in favorite-related workflows with the app's existing toast notification system.

# Changes Made
- Use toast feedback in `BookmarkButton`.
- Use toast feedback for unauthenticated favorite attempts on the Services page.
- Use toast feedback for favorite update failures on Worker Profile.
- Use toast feedback for saved worker removal failures.

# Testing
- Ran `npm run lint` in `client`.
- Ran `npm run build` in `client`.
- Searched favorite-related feedback strings to confirm alert replacement.

# Screenshots
UI behavior change only: browser alerts are replaced by existing toast notifications.

# Impact
Improves browsing and saved-worker UX by making favorite feedback non-blocking and consistent with the rest of the application.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered