### PR TITLE
fix(toasts): support object payloads

### DIFF
--- a/client/src/context/ToastContext.jsx
+++ b/client/src/context/ToastContext.jsx
@@ -5,9 +5,16 @@ const ToastContext = createContext(null);
 export const ToastProvider = ({ children }) => {
   const [toasts, setToasts] = useState([]);
 
-  const showToast = useCallback((message, type = 'success') => {
+  const showToast = useCallback((messageOrToast, type = 'success') => {
     const id = Math.random().toString(36).substr(2, 9);
-    const toast = { id, message, type };
+    const toast =
+      typeof messageOrToast === 'object' && messageOrToast !== null
+        ? {
+            id,
+            message: messageOrToast.message,
+            type: messageOrToast.type || type,
+          }
+        : { id, message: messageOrToast, type };
 
     setToasts(prev => [...prev, toast]);
 


### PR DESCRIPTION
# Related Issue
Closes #643

# Summary
This PR makes the toast provider compatible with both string-based and object-based toast calls.

# Changes Made
- Accept structured toast objects with `message` and `type`.
- Preserve existing `showToast(message, type)` behavior.
- Ensure object-style error toasts receive the intended visual style.

# Testing
- Confirmed object-style toast callers exist in the codebase.
- Ran `npm run lint` in `client`.
- Ran `npm run build` in `client`.

# Screenshots
Not applicable. This fixes notification rendering behavior.

# Impact
Improves reliability of shared toast feedback and prevents incorrectly styled notifications.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered