### PR TITLE
refactor(auth): throw typed service errors

### DIFF
--- a/client/src/services/authService.js
+++ b/client/src/services/authService.js
@@ -1,15 +1,18 @@
 import api from "./apiClient";
 
+const createServiceError = (error, fallbackMessage) => {
+  const serviceError = new Error(error.response?.data?.message || fallbackMessage);
+  serviceError.status = error.response?.status;
+  return serviceError;
+};
+
 export const signupUser = async (data) => {
   try {
     const response = await api.post("/auth/register", data);
     return response.data;
   } catch (error) {
     console.error(error.response?.data?.message || error);
-    throw {
-      message: error.response?.data?.message || "Registration failed",
-      status: error.response?.status,
-    };
+    throw createServiceError(error, "Registration failed");
   }
 };
 
@@ -19,10 +22,7 @@ export const loginUser = async (data) => {
     return response.data;
   } catch (error) {
     console.error(error.response?.data?.message || error);
-    throw {
-      message: error.response?.data?.message || "Login failed",
-      status: error.response?.status,
-    };
+    throw createServiceError(error, "Login failed");
   }
 };
 
@@ -32,10 +32,7 @@ export const getProfile = async () => {
     return response.data;
   } catch (error) {
     console.error(error.response?.data?.message || error);
-    throw {
-      message: error.response?.data?.message || "failed to fetch profile",
-      status: error.response?.status,
-    };
+    throw createServiceError(error, "failed to fetch profile");
   }
 };
 
@@ -45,10 +42,7 @@ export const updateProfile = async (data) => {
     return response.data;
   } catch (error) {
     console.error(error.response?.data?.message || error);
-    throw {
-      message: error.response?.data?.message || "Failed to update profile",
-      status: error.response?.status,
-    };
+    throw createServiceError(error, "Failed to update profile");
   }
 };
 
@@ -61,12 +55,7 @@ export const forgotUserPassword = async (email) => {
 
     return response.data;
   } catch (error) {
-    throw {
-      message:
-        error.response?.data?.message ||
-        "Failed to send reset link",
-      status: error.response?.status,
-    };
+    throw createServiceError(error, "Failed to send reset link");
   }
 };
 
@@ -79,12 +68,7 @@ export const resetUserPassword = async (token, password) => {
 
     return response.data;
   } catch (error) {
-    throw {
-      message:
-        error.response?.data?.message ||
-        "Failed to reset password",
-      status: error.response?.status,
-    };
+    throw createServiceError(error, "Failed to reset password");
   }
 };
 
@@ -99,12 +83,7 @@ export const forgotWorkerPassword = async (email) => {
 
     return response.data;
   } catch (error) {
-    throw {
-      message:
-        error.response?.data?.message ||
-        "Failed to send reset link",
-      status: error.response?.status,
-    };
+    throw createServiceError(error, "Failed to send reset link");
   }
 };
 
@@ -117,12 +96,7 @@ export const resetWorkerPassword = async (token, password) => {
 
     return response.data;
   } catch (error) {
-    throw {
-      message:
-        error.response?.data?.message ||
-        "Failed to reset password",
-      status: error.response?.status,
-    };
+    throw createServiceError(error, "Failed to reset password");
   }
 };
 


### PR DESCRIPTION
# Related Issue
Closes #645

# Summary
This PR refactors the auth service to throw real `Error` instances instead of plain objects, while preserving the current error contract used by UI callers.

# Changes Made
- Add a shared auth service error helper.
- Replace repeated plain-object throws with typed Error instances.
- Preserve `.status` metadata on thrown errors.
- Keep existing fallback messages unchanged.

# Testing
- Confirmed no plain-object throws remain in `authService`.
- Ran `npm run lint` in `client`.
- Ran `npm run build` in `client`.

# Screenshots
Not applicable. This is a service-layer maintainability change.

# Impact
Improves debugging, stack traces, and consistency of auth error handling without changing user-facing behavior.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered