### PR TITLE
Favorites (bookmark workers) with “quick booking”

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
+import { useAuth } from './context/AuthContext';
 
 // ─── Layout Components (always loaded — tiny, needed immediately) ─────────────
 import Navbar          from './components/Navbar';
@@ -41,12 +42,26 @@ const ResetPasswordWorker = lazy(()=>import('./pages/ResetPasswordWorker'));
 
 // ─── Route Definitions ────────────────────────────────────────────────────────
 // Grouped for clarity and easy future additions
+// ---------------- Auth Guard ----------------
+// User-protected routes (client-side guard).
+// Backend still enforces authorization via JWT middleware.
+function RequireAuth({ children }) {
+  const { isAuthenticated, authLoading } = useAuth();
+
+  if (authLoading) {
+    return <div className="flex min-h-[40vh] items-center justify-center">Loading...</div>;
+  }
+
+  return isAuthenticated ? children : <Login />;
+}
+
 const ROUTES = [
   // Core
   { path: '/',                  element: <Home /> },
   { path: '/login',             element: <Login /> },
   { path: '/register',          element: <Register /> },
   { path: '/dashboard',         element: <Dashboard /> },
+
 
   // auth - forgot and reset password routes
   { path: '/forgot-password', element: <ForgotPasswordUser/>},
@@ -64,9 +79,12 @@ const ROUTES = [
   { path: '/saved-workers',     element: <SavedWorkers /> },
   { path: '/recommendations',   element: <Recommendations /> }, // ✨ NEW
 
-  // User
-  { path: '/profile',           element: <Profile /> },
-  { path: '/bookings',          element: <Bookings /> },
+  // User (protected)
+  { path: '/profile',           element: <RequireAuth><Profile /></RequireAuth> },
+  { path: '/bookings',          element: <RequireAuth><Bookings /></RequireAuth> },
+
+
+
 
   // Info & Support
   { path: '/help',              element: <HelpCenter /> },

--- a/client/src/pages/SavedWorkers.jsx
+++ b/client/src/pages/SavedWorkers.jsx
@@ -174,6 +174,11 @@ const WorkerCard = ({ favorite, onRemove }) => {
 
   const navigate = useNavigate();
 
+  const quickBook = () => {
+    if (!worker?._id) return;
+    navigate(`/worker/${worker._id}?quickBook=1`);
+  };
+
   return (
     <div
       style={styles.card}
@@ -186,6 +191,7 @@ const WorkerCard = ({ favorite, onRemove }) => {
         e.currentTarget.style.boxShadow = "0 4px 24px rgba(0,0,0,0.08)";
       }}
     >
+
       {/* Remove button */}
       <button
         style={styles.removeBtn}
@@ -247,15 +253,26 @@ const WorkerCard = ({ favorite, onRemove }) => {
         })}
       </p>
 
-      {/* View Profile button */}
+      {/* Quick booking button */}
       <button
         style={styles.viewBtn}
-        onClick={() => navigate(`/worker/${worker._id}`)}
+        onClick={quickBook}
         onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.88")}
+        onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
+      >
+        Book now ⚡
+      </button>
+
+      {/* View Profile button */}
+      <button
+        style={{ ...styles.viewBtn, background: "#fff", color: "#4b4b6a", border: "1.5px solid #dde1e7", marginTop: "10px" }}
+        onClick={() => navigate(`/worker/${worker._id}`)}
+        onMouseEnter={(e) => (e.currentTarget.style.opacity = "0.9")}
         onMouseLeave={(e) => (e.currentTarget.style.opacity = "1")}
       >
         View Profile →
       </button>
+
     </div>
   );
 };
@@ -267,36 +284,77 @@ const SavedWorkers = () => {
   const [favorites, setFavorites] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+
+  const FAVORITES_CACHE_KEY = "favoritesCache";
+  const FAVORITES_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
   const navigate = useNavigate();
   const { showToast } = useToast();
 
   useEffect(() => {
-    const fetchFavorites = async () => {
+    let cancelled = false;
+
+    const loadCachedThenRefresh = async () => {
+      try {
+        const raw = localStorage.getItem(FAVORITES_CACHE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          const age = Date.now() - (parsed?.cachedAt || 0);
+          if (Array.isArray(parsed?.favorites) && age < FAVORITES_CACHE_TTL_MS) {
+            if (!cancelled) {
+              setFavorites(parsed.favorites);
+              setLoading(false);
+            }
+          }
+        }
+      } catch {
+        // Ignore cache failures
+      }
+
       try {
         const data = await getFavorites();
-        setFavorites(data);
+        if (!cancelled) {
+          setFavorites(data);
+          setLoading(false);
+          localStorage.setItem(
+            FAVORITES_CACHE_KEY,
+            JSON.stringify({ cachedAt: Date.now(), favorites: data })
+          );
+        }
       } catch (err) {
-        setError(
-          err.message === "User not authenticated"
-            ? "Please login to view your saved workers."
-            : "Failed to load saved workers. Try again."
-        );
-      } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setError(
+            err.message === "User not authenticated"
+              ? "Please login to view your saved workers."
+              : "Failed to load saved workers. Try again."
+          );
+          setLoading(false);
+        }
       }
     };
 
-    fetchFavorites();
+    loadCachedThenRefresh();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
 
   const handleRemove = async (workerId) => {
     try {
       await removeFavorite(workerId);
-      setFavorites((prev) => prev.filter((fav) => fav.worker._id !== workerId));
+      const next = favorites.filter((fav) => fav.worker._id !== workerId);
+      setFavorites(next);
+      localStorage.setItem(
+        FAVORITES_CACHE_KEY,
+        JSON.stringify({ cachedAt: Date.now(), favorites: next })
+      );
     } catch (err) {
       showToast("Failed to remove saved worker. Try again.", "error");
     }
   };
+
 
   return (
     <div style={styles.page}>

--- a/client/src/pages/WorkerProfile.jsx
+++ b/client/src/pages/WorkerProfile.jsx
@@ -1,5 +1,6 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useMemo, useState, useEffect } from "react";
+
 import api from "../services/apiClient";
 import { getEstimatorConfig } from "../utils/estimatorConfig";
 import {
@@ -259,6 +260,8 @@ const parsePriceToNumber = (price) => {
 const WorkerProfile = () => {
   const { id } = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
   const { isAuthenticated } = useAuth();
   const { showToast } = useToast();
 
@@ -456,7 +459,24 @@ const WorkerProfile = () => {
     [worker]
   );
 
+  // Auto-trigger quick booking when navigated here from Saved Workers.
+  // Usage: /worker/:id?quickBook=1
+  const [autoQuickBookStarted, setAutoQuickBookStarted] = useState(false);
+  useEffect(() => {
+    const shouldQuickBook = searchParams.get("quickBook") === "1";
+    if (!shouldQuickBook) return;
+    if (!worker) return;
+    if (autoQuickBookStarted) return;
+
+    // Once we have the worker and estimator readiness, kick off booking.
+    setAutoQuickBookStarted(true);
+    // handleBooking may redirect to /login when unauthenticated.
+    handleBooking();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, worker, autoQuickBookStarted, hasEstimator]);
+
   /* ── Quick book — show estimate prompt if config exists, else book directly ── */
+
   const handleBooking = () => {
     if (!worker) return;
     // Booking is a server-side action tied to the authenticated user; bounce


### PR DESCRIPTION
Implemented “Favorites + Quick booking” for saved workers.

Changes:

client/src/pages/SavedWorkers.jsx
Added “Book now ⚡” button on each saved worker card.
Button navigates to the worker profile with query: /worker/:id?quickBook=1
Added client-side caching for favorites using localStorage (key: favoritesCache, TTL: 5 minutes).
Updated cache after removing a favorite.
client/src/pages/WorkerProfile.jsx
Added support for query param quickBook=1.
When present and the worker is loaded, it automatically triggers the existing quick-book flow (including estimate prompt when applicable).


closes #617