### PR TITLE
fix(backend): fix undefined schema field references in createReview

### DIFF
--- a/server/controllers/reviewController.js
+++ b/server/controllers/reviewController.js
@@ -40,7 +40,7 @@ export const createReview = async (req, res) => {
       });
     }
 
-    if (booking.user.toString() !== req.user._id.toString()) {
+    if (booking.userId.toString() !== req.user._id.toString()) {
       return res.status(403).json({
         success: false,
         message: 'Not authorized: You can only review your own bookings'
@@ -62,7 +62,7 @@ export const createReview = async (req, res) => {
       reviewText,
       bookingReference,
       user: req.user._id,
-      worker: booking.worker
+      worker: booking.workerId
     });
 
     res.status(201).json({


### PR DESCRIPTION
##  Bug Fix: Undefined Schema Field References in `createReview`

### Problem
The `createReview` endpoint (`POST /api/reviews`) was broken and would throw a runtime crash every time a user tried to submit a review. 

Specifically, the code attempted to access:
- `booking.user.toString()` (Line 43)
- `worker: booking.worker` (Line 65)

However, according to the `Booking` model schema, these fields do not exist. The actual fields are `userId` and `workerId`. This resulted in a `TypeError: Cannot read properties of undefined (reading 'toString')` when the endpoint was called.

### Solution
Updated the field references to correctly match the schema:
- `booking.user` ➡️ `booking.userId`
- `booking.worker` ➡️ `booking.workerId`

This allows the `createReview` endpoint to successfully validate the user and correctly map the worker to the new review.