### PR TITLE
fix(backend): prevent loginWorker crash when email or password is not provided

### DIFF
--- a/server/controllers/workerController.js
+++ b/server/controllers/workerController.js
@@ -117,6 +117,12 @@ export const loginWorker = async (req, res) => {
   try {
     const { email, password } = req.body;
 
+    if (!email || !password) {
+      return res.status(400).json({
+        success: false,
+        message: "Please provide an email and password",
+      });
+    }
     const normalizedEmail = email.toLowerCase().trim();
 
     const emailRegex =


### PR DESCRIPTION
## Bug Fix: loginWorker crashes with TypeError when no email is provided

### Problem
The loginWorker endpoint (POST /api/workers/login) in workerController.js assumed that email and password would always be provided in the request body. If the client sent a request without an email field, the code crashed with TypeError: Cannot read properties of undefined (reading toLowerCase) on line 120. This caused a 500 Server Error.

### Solution
Added an explicit check to verify that both email and password exist before attempting to call .toLowerCase() on the email. If they are missing, it now properly returns a 400 Bad Request with an appropriate message.