### PR TITLE
fix: prevent getNearbyIssues from filtering by undefined category & fix client CI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -46,19 +46,6 @@ const ResetPasswordUser = lazy(()=>import('./pages/ResetPasswordUser'));
 const ForgotPasswordWorker = lazy(()=>import('./pages/ForgotPasswordWorker'));
 const ResetPasswordWorker = lazy(()=>import('./pages/ResetPasswordWorker'));
 
-const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
-const Contact = lazy(() => import("./components/Contact"));
-const Community = lazy(() => import("./pages/Community"));
-const Feedback = lazy(() => import("./pages/Feedback"));
-const FAQ = lazy(() => import("./pages/FAQ"));
-const SavedWorkers = lazy(() => import("./pages/SavedWorkers"));
-const Recommendations = lazy(() => import("./pages/Recommendations")); // ✨ NEW
-const NotFound = lazy(() => import("./pages/NotFound"));
-
-const ForgotPasswordUser = lazy(() => import("./pages/ForgotPasswordUser"));
-const ResetPasswordUser = lazy(() => import("./pages/ResetPasswordUser"));
-const ForgotPasswordWorker = lazy(() => import("./pages/ForgotPasswordWorker"));
-const ResetPasswordWorker = lazy(() => import("./pages/ResetPasswordWorker"));
 
 // ─── Route Definitions ────────────────────────────────────────────────────────
 // Grouped for clarity and easy future additions

--- a/server/controllers/issueController.js
+++ b/server/controllers/issueController.js
@@ -39,7 +39,12 @@ export const getNearbyIssues = async (req, res) => {
             key: 'location'
           }
         },
-        { $match: { status: { $nin: ['resolved', 'closed'] } } },
+        { 
+          $match: { 
+            status: { $nin: ['resolved', 'closed'] },
+            ...(category ? { category } : {})
+          } 
+        },
         {
           $group: {
             _id: {
@@ -55,8 +60,7 @@ export const getNearbyIssues = async (req, res) => {
     }
 
     // Project fields: performance optimization
-    const issues = await Issue.find({
-      category,
+    let query = {
       status: { $nin: ['resolved', 'closed'] },
       location: {
         $near: {
@@ -64,7 +68,12 @@ export const getNearbyIssues = async (req, res) => {
           $maxDistance: maxDistanceMeters
         }
       }
-    }).select("title description category location latitude longitude status upvotes reportedAt").limit(100);
+    };
+    if (category) {
+      query.category = category;
+    }
+
+    const issues = await Issue.find(query).select("title description category location latitude longitude status upvotes reportedAt").limit(100);
 
     return res.status(200).json({ type: 'list', data: issues });
   } catch (err) {


### PR DESCRIPTION
## Bug Fix:  filters by undefined category & CI fixes

### Problem
1. **API Bug**: The  endpoint in  unconditionally added  to the MongoDB query filter. If the request did not specify a category (e.g. ), the query would strictly search for issues where , effectively hiding all nearby issues from the map.
2. **CI Bug**: The client CI step for  was failing due to duplicated lazy page imports in  throwing ESLint parsing errors ().

### Solution
1. **Backend**: Rewrote the query in  to conditionally include the  filter only if it is actually provided in the request. This fix was applied to both the general list query and the server-side clustering  aggregation stage.
2. **Frontend**: Cleaned up the duplicate imports in  so that the client linting checks turn green.