### PR TITLE
fix: remove duplicate averageRating field and standardize JWT expiry

### DIFF
--- a/server/controllers/workerController.js
+++ b/server/controllers/workerController.js
@@ -12,7 +12,7 @@ const generateToken = (id) => {
   return jwt.sign(
     { id },
     process.env.JWT_SECRET,
-    { expiresIn: "7d" }
+    { expiresIn: "30d" }
   );
 };
 

--- a/server/models/Worker.js
+++ b/server/models/Worker.js
@@ -85,10 +85,7 @@ const workerSchema = new mongoose.Schema(
     resetPasswordExpire: {
       type: Date,
     },
-    averageRating: {
-      type: Number,
-      default: 0,
-    },
+
     reviewCount: {
       type: Number,
       default: 0,


### PR DESCRIPTION
## Bug Fix: Model duplicates and JWT inconsistency

### Problem
1. **Duplicate Schema Field**: The `Worker` model schema incorrectly defined the `averageRating` field twice, which could lead to unexpected mongoose behavior or validation warnings.
2. **Inconsistent JWT Expiry**: The backend was generating auth tokens for users with a `30d` expiration (in `authController.js`), while workers were only getting a `7d` expiration (in `workerController.js`), resulting in an inconsistent login experience.

### Solution
1. **Schema Fix**: Removed the duplicate `averageRating` field definition from `server/models/Worker.js`.
2. **Auth Fix**: Updated the `generateToken` method in `server/controllers/workerController.js` to use a `30d` expiration, matching the user authentication logic.