### PR TITLE
Fix: SOS button overlaps scroll-to-top button on multiple pages (#684)

### DIFF
--- a/client/src/components/SOSButton.css
+++ b/client/src/components/SOSButton.css
@@ -1,7 +1,7 @@
 /* fixed to bottom right so it's always visible on every page */
 .sos-wrapper {
   position: fixed;
-  bottom: 32px;
+  bottom: 100px;   /* was 32px — raised so it clears the scroll-to-top button */
   right: 32px;
   z-index: 9999;
   display: flex;
@@ -9,6 +9,7 @@
   align-items: flex-end;
   gap: 12px;
 }
+
 .sos-btn {
   position: relative;
   width: 72px;
@@ -138,7 +139,7 @@
   }
 
   .sos-wrapper {
-    bottom: 20px;
+    bottom: 80px;   /* was 20px — same fix for small screens */
     right: 20px;
   }
 }


### PR DESCRIPTION

## 📝 Related Issue
Closes #684

## 📋 Summary
The SOS button and scroll-to-top button are both fixed-position elements anchored to the bottom-right corner of the screen. When both were visible at the same time, they overlapped, making it difficult to click either one reliably. This PR adjusts the vertical offset of the SOS button wrapper so it stacks above the scroll-to-top button instead of covering it, on both desktop and mobile breakpoints.

## 🛠️ Changes Made
- **Backend**:
  - No backend changes.
- **Frontend**:
  - Updated `client/src/components/SOSButton.css`
  - Increased `.sos-wrapper` `bottom` offset from `32px` to `100px` on desktop so it clears the scroll-to-top button.
  - Increased the mobile `@media (max-width: 640px)` `.sos-wrapper` `bottom` offset from `20px` to `80px` for the same reason on smaller screens.
- **Config & Workflows**:
  - No config or dependency changes intended (please ignore any unrelated `package-lock.json` diff if present — not part of this fix).

## 🧪 Testing Verification
- **Local Integration Testing**:
  - Ran `npm run dev` in `client/` and verified the change locally at `localhost:5173`.
- **Responsiveness Verification**:
  - Verified spacing on desktop width and mobile width (via browser dev tools device toolbar) — buttons no longer overlap on either.
- **Accessibility Verification**:
  - No changes to markup, ARIA attributes, or focus order — only positioning offsets were modified.
- **Security Checkpoints**:
  - Not applicable (CSS-only change, no data handling involved).

