### PR TITLE
fix: enforce password policy on profile updates

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -23,7 +23,7 @@ const isValidEmail = (email) => {
 
 // Follows same rules as already existing login controller
 const isValidPassword = (password) => {
-  if (!password || password.length < 6) {
+  if (typeof password !== 'string' || password.length < 6) {
     return false;
   }
 
@@ -149,6 +149,12 @@ export const getUserProfile = async (req, res) => {
 
 export const updateUserProfile = async (req, res) => {
   try {
+    if (req.body.password && !isValidPassword(req.body.password)) {
+      return res.status(400).json({
+        message: "Password must contain uppercase, lowercase and a number and be at least 6 characters long",
+      });
+    }
+
     const user = await User.findById(req.user._id);
 
     if (user) {

--- a/server/tests/verifyProfilePasswordValidation.js
+++ b/server/tests/verifyProfilePasswordValidation.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { updateUserProfile } from '../controllers/authController.js';
+
+const invalidPasswords = ['short', 'alllowercase1', 'ALLUPPERCASE1', 'NoNumber', []];
+
+for (const password of invalidPasswords) {
+  let statusCode;
+  let responseBody;
+  const req = {
+    user: { _id: '507f1f77bcf86cd799439011' },
+    body: { password },
+  };
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(payload) {
+      responseBody = payload;
+      return this;
+    },
+  };
+
+  await updateUserProfile(req, res);
+
+  assert.equal(statusCode, 400);
+  assert.deepEqual(responseBody, {
+    message: 'Password must contain uppercase, lowercase and a number and be at least 6 characters long',
+  });
+}
+
+console.log('Profile password policy tests passed.');
+process.exit(0);


### PR DESCRIPTION
### Summary

Applies the existing account password policy when authenticated users change their password through profile updates.

### Problem

Registration and password-reset flows require at least six characters with uppercase, lowercase, and numeric characters, but `updateUserProfile` accepted any truthy password. Users could therefore replace a compliant password with a weak value.

### Solution

Reuse the controller's existing password-policy helper before loading or modifying the user. The helper now safely rejects non-string values as well.

### Changes

- Enforced the existing password rules in profile updates.
- Hardened the shared validator against non-string input.
- Added regression coverage for short, missing-character-class, and non-string passwords.

### Validation

- `node tests/verifyProfilePasswordValidation.js` in `server` — passed.
- `node --check controllers/authController.js` in `server` — passed.
- `node --check tests/verifyProfilePasswordValidation.js` in `server` — passed.
- `git diff --check` — passed.

### Test Cases

- Short, lowercase-only, uppercase-only, numberless, and array-valued passwords return HTTP 400 before database access.

### Screenshots

Not applicable.

### Database or Migration Impact

None. Existing password hashes and user records are unchanged.

### API Impact

`PUT /api/auth/profile` now returns HTTP 400 when a supplied password violates the existing account password policy. Profile updates without a password and compliant password changes remain compatible.

### Risks and Trade-offs

Clients previously sending weak passwords will receive a validation error. This intentional restriction aligns all password-setting flows.

### Deployment Notes

None.

### Checklist

- [x] Implementation is limited to the requested scope.
- [x] Existing validation logic was reused.
- [x] Tests were added.
- [x] Relevant tests and syntax checks pass.
- [ ] Full integration tests require external MongoDB and Redis services and were not run.
- [x] API compatibility impact is documented.
- [x] No secrets or sensitive data were committed.
- [x] Authentication security was strengthened.
- [x] The final diff was reviewed.
