### PR TITLE
fix: preserve accurate saved-worker ratings

### DIFF
--- a/server/controllers/favoriteController.js
+++ b/server/controllers/favoriteController.js
@@ -1,6 +1,8 @@
 import Favorite from '../models/Favorite.js';
 import Worker from '../models/Worker.js';
 
+export const normalizeWorkerRating = (rating) => rating ?? 0;
+
 // @desc    Add a worker to favorites
 // @route   POST /api/favorites/:workerId
 // @access  Private (User only)
@@ -89,7 +91,7 @@ export const getFavorites = async (req, res, next) => {
           name: fav.workerId.name,
           category: fav.workerId.category,
           skill: fav.workerId.category, // fallback for skill Badge
-          rating: fav.workerId.averageRating || 5.0,
+          rating: normalizeWorkerRating(fav.workerId.averageRating),
           experience: fav.workerId.experience ? parseInt(fav.workerId.experience) || 0 : 0,
           location: fav.workerId.locationName || 'Nearby',
           profilePic: fav.workerId.profilePicture || null, // Map from profilePicture in Worker Model

--- a/server/tests/verifyFavoriteRating.js
+++ b/server/tests/verifyFavoriteRating.js
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { normalizeWorkerRating } from '../controllers/favoriteController.js';
+
+assert.equal(normalizeWorkerRating(0), 0);
+assert.equal(normalizeWorkerRating(4.7), 4.7);
+assert.equal(normalizeWorkerRating(null), 0);
+assert.equal(normalizeWorkerRating(undefined), 0);
+
+console.log('Favorite worker rating normalization tests passed.');


### PR DESCRIPTION
### Summary

Preserves accurate zero and unrated scores when returning a user's saved workers.

### Problem

The favorites response used `averageRating || 5.0`. Because zero is falsy, new or unrated workers were presented with a perfect 5.0 rating, creating misleading UI data.

### Solution

Normalize only nullish ratings to the Worker model's zero default while preserving every valid numeric rating, including zero.

### Changes

- Replaced the truthy fallback with a reusable nullish rating normalizer.
- Added regression coverage for zero, positive, null, and undefined ratings.

### Validation

- `node tests/verifyFavoriteRating.js` in `server` — passed.
- `node --check controllers/favoriteController.js` in `server` — passed.
- `node --check tests/verifyFavoriteRating.js` in `server` — passed.
- `git diff --check` — passed.

### Test Cases

- Zero remains zero.
- A valid decimal rating remains unchanged.
- Null and undefined ratings fall back to zero.

### Screenshots

Not applicable. This corrects API data consumed by the saved-workers UI.

### Database or Migration Impact

None.

### API Impact

`GET /api/favorites` now returns `rating: 0` for unrated workers instead of incorrectly returning `rating: 5`. The response schema is unchanged.

### Risks and Trade-offs

Consumers that accidentally relied on the fabricated 5.0 fallback will now receive the model-consistent value of zero.

### Deployment Notes

None.

### Checklist

- [x] Implementation is limited to the requested scope.
- [x] Existing model semantics were preserved.
- [x] Tests were added.
- [x] Relevant tests and syntax checks pass.
- [ ] Full integration tests require external MongoDB and Redis services and were not run.
- [x] API behavior change is documented.
- [x] No secrets or sensitive data were committed.
- [x] Backward compatibility was considered.
- [x] The final diff was reviewed.
