### PR TITLE
Unified “booking timeline” (activity feed) per booking

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -45,7 +45,7 @@ const CivicIssues         = lazy(() => import('./pages/CivicIssues'));
 const ReportIssue         = lazy(() => import('./components/IssueSubmissionForm'));
 const IssueDetail         = lazy(() => import('./pages/IssueDetail'));
 const NotFound            = lazy(() => import('./pages/NotFound'));
-const NotFound            = lazy(() => import('./pages/NotFound'));
+
 
 const AdminDashboard      = lazy(() => import('./pages/admin/AdminDashboard'));
 const AdminUsers          = lazy(() => import('./pages/admin/AdminUsers'));

--- a/client/src/pages/Bookings.jsx
+++ b/client/src/pages/Bookings.jsx
@@ -84,6 +84,25 @@ const normalizeBooking = (booking) => {
     formattedDate = new Date(booking.createdAt || Date.now()).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' });
   }
 
+  // Normalize backend `statusHistory` into unified `events` timeline.
+  // Each event is: { status, at, message }
+  const rawStatusHistory = Array.isArray(booking.statusHistory)
+    ? booking.statusHistory
+    : [];
+
+  const events = rawStatusHistory
+    .map((e) => ({
+      status: e?.status,
+      at: e?.changedAt ? new Date(e.changedAt).toISOString() : null,
+      message: e?.note || "",
+    }))
+    .filter((e) => e.status)
+    .sort((a, b) => {
+      const atA = a.at ? new Date(a.at).getTime() : 0;
+      const atB = b.at ? new Date(b.at).getTime() : 0;
+      return atA - atB;
+    });
+
   return {
     ...booking,
     id: booking._id || booking.id,
@@ -93,11 +112,122 @@ const normalizeBooking = (booking) => {
     date: formattedDate,
     estimateSpecs,
     status,
+    events,
   };
 };
 
+
 /* ── Estimate breakdown panel for a booking card ── */
+const TimelineDot = ({ variant }) => {
+  const className =
+    variant === "completed"
+      ? "bg-emerald-500"
+      : variant === "cancelled"
+        ? "bg-rose-500"
+        : variant === "active"
+          ? "bg-blue-500"
+          : "bg-slate-300";
+  return <span className={`inline-block w-2.5 h-2.5 rounded-full ${className}`} />;
+};
+
+const formatEventAt = (at) => {
+  if (!at) return "";
+  const d = new Date(at);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleString([], { dateStyle: "medium", timeStyle: "short" });
+};
+
+const BookingTimeline = ({ booking }) => {
+  const status = booking.status;
+
+  const steps = [
+    { key: "Pending", label: "Pending" },
+    { key: "Confirmed", label: "Confirmed" },
+    { key: "Technician En Route", label: "En Route" },
+    { key: "Completed", label: "Completed" },
+    { key: "Cancelled", label: "Cancelled" },
+  ];
+
+  // Prefer events; fallback to inferred timestamps.
+  const events = Array.isArray(booking.events) ? booking.events : [];
+
+  const eventByStatus = new Map(
+    events.map((e) => [e.status, e]).filter(([k]) => !!k)
+  );
+
+  const createdAt = booking.createdAt ? new Date(booking.createdAt).toISOString() : null;
+  const scheduledAt = booking.scheduledTime ? new Date(booking.scheduledTime).toISOString() : null;
+
+  const timelineItems = steps.map((s) => {
+    let at = eventByStatus.get(s.key)?.at || null;
+    let message = eventByStatus.get(s.key)?.message || "";
+
+    // Fallbacks
+    if (!at) {
+      if (s.key === "Pending") at = createdAt || null;
+      if (s.key === "Confirmed") at = scheduledAt || null;
+      if (s.key === "Technician En Route") at = null;
+      if (s.key === "Completed" || s.key === "Cancelled") at = booking.updatedAt ? new Date(booking.updatedAt).toISOString() : null;
+    }
+
+    return { ...s, at, message };
+  });
+
+  const currentIndex = Math.max(
+    0,
+    steps.findIndex((s) => s.key === status) // if status matches one of the keys
+  );
+
+  return (
+    <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <h4 className="text-sm font-bold text-slate-800">Booking Timeline</h4>
+        <span className="text-xs font-medium text-slate-500">{status}</span>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {timelineItems.map((item, idx) => {
+          const isReached = item.key === status || idx <= currentIndex;
+          const variant = item.key === "Completed" && status === "Completed"
+            ? "completed"
+            : item.key === "Cancelled" && status === "Cancelled"
+              ? "cancelled"
+              : isReached
+                ? "active"
+                : "pending";
+
+          // Hide En Route step if it has no event and booking isn't yet in that state.
+          const shouldHideEnRoute = item.key === "Technician En Route" && !item.at && status !== "Technician En Route";
+          if (shouldHideEnRoute) return null;
+
+          return (
+            <div key={item.key} className="flex items-start gap-3">
+              <div className="pt-1">
+                <TimelineDot variant={variant} />
+              </div>
+              <div className="flex-1">
+                <div className="flex items-center justify-between gap-2">
+                  <span className={`text-sm font-semibold ${isReached ? "text-slate-900" : "text-slate-500"}`}>
+                    {item.label}
+                  </span>
+                  <span className={`text-xs ${isReached ? "text-slate-600" : "text-slate-400"}`}>
+                    {formatEventAt(item.at) || "—"}
+                  </span>
+                </div>
+                {item.message ? (
+                  <p className="mt-1 text-xs text-slate-600 leading-relaxed">{item.message}</p>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
 const EstimateBreakdown = ({ specs }) => {
+
   const [open, setOpen] = useState(false);
   // Guard against divide-by-zero when a malformed estimate has no total.
   const total = specs.totalCost > 0 ? specs.totalCost : 0;
@@ -492,6 +622,7 @@ const Bookings = () => {
               {/* RESCHEDULE BOX */}
               {reschedulingId === booking.id && (
                 <div className="mt-4 p-5 rounded-2xl border border-blue-100 bg-blue-50/50 space-y-3 max-w-md transition-all duration-300">
+
                   <h4 className="text-sm font-bold text-slate-800">Reschedule Booking</h4>
                   <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                     <input
@@ -530,12 +661,16 @@ const Bookings = () => {
                 </div>
               )}
 
+              {/* BOOKING TIMELINE */}
+              <BookingTimeline booking={booking} />
+
               {/* ESTIMATE BREAKDOWN */}
               {booking.estimateSpecs && (
                 <EstimateBreakdown specs={booking.estimateSpecs} />
               )}
 
               {/* REVIEW BOX */}
+
               {activeReview === booking.id && (
                 <div className="mt-6 relative overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-lg">
 

--- a/client/src/services/apiClient.js
+++ b/client/src/services/apiClient.js
@@ -7,13 +7,14 @@ const normalizeApiBaseURL = (value) => {
 };
 
 const api = axios.create({
-   baseURL: normalizeApiBaseURL(import.meta.env.VITE_API_URL),
-    headers:{
-        "Content-Type":"application/json"
-    },
-    timeout:15000,
-    withCredentials: true,
+  baseURL: normalizeApiBaseURL(import.meta.env.VITE_API_URL),
+  headers: {
+    "Content-Type": "application/json",
+  },
+  timeout: 15000,
+  withCredentials: true,
 });
+
 
 const TIMING_THRESHOLD_SLOW = 3000;
 
@@ -29,8 +30,11 @@ api.interceptors.response.use(
   (response) => {
     if (response.headers["x-csrf-token"]) {
       sessionStorage.setItem("csrf_token", response.headers["x-csrf-token"]);
+    }
+
     const startTime = response.config?.metadata?.startTime;
     if (startTime) {
+
       const duration = performance.now() - startTime;
       const method = (response.config.method || 'GET').toUpperCase();
       const url = response.config.url || '';


### PR DESCRIPTION
Added unified “booking timeline” (activity feed) per booking card on client/src/pages/Bookings.jsx.

Updated normalizeBooking() to expose events by mapping backend booking.statusHistory into events: [{ status, at, message }].
Added BookingTimeline UI under each booking card showing the chronological steps (Pending → Confirmed → En Route → Completed/Cancelled).
Implemented fallbacks when event timestamps are missing (Pending uses createdAt, Confirmed uses scheduledTime, Completed/Cancelled uses updatedAt).


closes #794