### PR TITLE
feat: validate phone numbers during registration

### DIFF
--- a/server/middleware/validationMiddleware.js
+++ b/server/middleware/validationMiddleware.js
@@ -26,7 +26,7 @@ const PASSWORD_POLICY_MESSAGE =
   'a lowercase letter, a digit, and a special character.';
 
 export const validateRegistration = (req, res, next) => {
-  const { name, email, password } = req.body;
+  const { name, email, password, phone } = req.body;
 
   if (!name || typeof name !== 'string' || name.trim().length < 2) {
     return res.status(400).json({ error: 'Name is required and must be at least 2 characters.' });
@@ -43,6 +43,14 @@ export const validateRegistration = (req, res, next) => {
 
   if (!STRONG_PASSWORD_REGEX.test(password)) {
     return res.status(400).json({ error: PASSWORD_POLICY_MESSAGE });
+  }
+
+  if (phone !== undefined && phone !== '') {
+    if (typeof phone !== 'string' || !/^\d{10}$/.test(phone.trim())) {
+      return res.status(400).json({
+        error: 'Phone number must contain exactly 10 digits.',
+      });
+    }
   }
 
   next();

--- a/server/tests/verifyRegistrationPhoneValidation.js
+++ b/server/tests/verifyRegistrationPhoneValidation.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { validateRegistration } from '../middleware/validationMiddleware.js';
+
+const validBase = {
+  name: 'Test User',
+  email: 'test@example.com',
+  password: 'Password1!',
+};
+
+const invoke = (phone) => {
+  let statusCode;
+  let responseBody;
+  let nextCalled = false;
+  const req = { body: { ...validBase, phone } };
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(payload) {
+      responseBody = payload;
+      return this;
+    },
+  };
+
+  validateRegistration(req, res, () => {
+    nextCalled = true;
+  });
+  return { statusCode, responseBody, nextCalled };
+};
+
+for (const phone of ['12345', '12345678901', '123-456-7890', {}, null]) {
+  assert.deepEqual(invoke(phone), {
+    statusCode: 400,
+    responseBody: { error: 'Phone number must contain exactly 10 digits.' },
+    nextCalled: false,
+  });
+}
+
+for (const phone of ['9876543210', '', undefined]) {
+  assert.equal(invoke(phone).nextCalled, true);
+}
+
+console.log('Registration phone validation tests passed.');


### PR DESCRIPTION
### Summary

Adds server-side validation for optional user phone numbers during registration.

### Problem

The registration UI validates ten-digit phone numbers, but the API accepted malformed or non-string phone values. Direct API clients could bypass the browser check, and object values could later fail when the controller called `trim()`.

### Solution

Extend the existing registration validation middleware to accept omitted phone numbers while requiring supplied values to contain exactly ten digits.

### Changes

- Added optional phone validation to `validateRegistration`.
- Returns a consistent HTTP 400 validation error for malformed values.
- Added tests for length, punctuation, non-string, null, valid, empty, and omitted values.

### Validation

- `node tests/verifyRegistrationPhoneValidation.js` — passed.
- `node --check middleware/validationMiddleware.js` — passed.
- `node --check tests/verifyRegistrationPhoneValidation.js` — passed.
- `git diff --check` — passed.

### Test Cases

- Valid ten-digit number proceeds.
- Optional empty or omitted number proceeds.
- Short, long, formatted, object, and null values return HTTP 400.

### Screenshots

Not applicable; existing UI validation and presentation are unchanged.

### Database or Migration Impact

None.

### API Impact

`POST /api/auth/register` now rejects malformed supplied phone numbers with HTTP 400. Phone remains optional and the request/response schema is unchanged.

### Risks and Trade-offs

International formats are not introduced because the current UI and issue requirement specify ten digits. A future internationalization change should adopt E.164 end to end.

### Deployment Notes

None.

### Checklist

- [x] Implementation is limited to registration validation.
- [x] Existing middleware conventions were followed.
- [x] Success and invalid-input tests were added.
- [x] Relevant tests and syntax checks pass.
- [x] API impact is documented.
- [x] No schema migration is required.
- [x] No secrets were committed.
- [x] The final diff was reviewed.

Closes #45.
