### PR TITLE
feat: add liveness and readiness health endpoints

### DIFF
--- a/server/controllers/healthController.js
+++ b/server/controllers/healthController.js
@@ -1,0 +1,34 @@
+import mongoose from 'mongoose';
+
+const mongoStates = ['disconnected', 'connected', 'connecting', 'disconnecting'];
+
+export const createHealthHandlers = ({
+  connection = mongoose.connection,
+  startedAt = Date.now(),
+} = {}) => {
+  const live = (req, res) => {
+    res.status(200).json({
+      status: 'ok',
+      service: 'fixnearby-api',
+      uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
+      timestamp: new Date().toISOString(),
+    });
+  };
+
+  const ready = (req, res) => {
+    const databaseState = mongoStates[connection.readyState] || 'unknown';
+    const isReady = connection.readyState === 1;
+
+    res.status(isReady ? 200 : 503).json({
+      status: isReady ? 'ready' : 'not_ready',
+      dependencies: {
+        mongodb: databaseState,
+      },
+      timestamp: new Date().toISOString(),
+    });
+  };
+
+  return { live, ready };
+};
+
+export const healthHandlers = createHealthHandlers();

--- a/server/server.js
+++ b/server/server.js
@@ -31,6 +31,7 @@ import { checkUpcomingBookings } from './workers/bookingReminderWorker.js';
 import favoriteRoutes from './routes/favoriteRoutes.js';
 import estimateRoutes from './routes/estimateRoutes.js';
 import availabilityRoutes from './routes/availabilityRoutes.js';
+import { healthHandlers } from './controllers/healthController.js';
 import auditLogRoutes from './routes/auditLogRoutes.js';
 import earningRoutes from './routes/earningRoutes.js';
 import moderationRoutes from './routes/moderationRoutes.js';
@@ -182,10 +183,10 @@ app.get('/api/protected', authMiddleware, (req, res) => {
   });
 });
 
-// Basic health check route
-app.get('/api/health', (req, res) => {
-  res.status(200).json({ status: 'success', message: 'FixNearby API is running' });
-});
+// Liveness remains available at the legacy path for platform compatibility.
+app.get('/api/health', healthHandlers.live);
+app.get('/api/health/live', healthHandlers.live);
+app.get('/api/health/ready', healthHandlers.ready);
 
 // Client-side UI error reporting endpoint
 app.post('/api/logs/error', (req, res) => {

--- a/server/tests/verifyHealthEndpoints.js
+++ b/server/tests/verifyHealthEndpoints.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { createHealthHandlers } from '../controllers/healthController.js';
+
+const invoke = (handler) => {
+  let statusCode;
+  let body;
+  const res = {
+    status(code) {
+      statusCode = code;
+      return this;
+    },
+    json(payload) {
+      body = payload;
+      return this;
+    },
+  };
+  handler({}, res);
+  return { statusCode, body };
+};
+
+const connected = createHealthHandlers({ connection: { readyState: 1 }, startedAt: Date.now() - 2000 });
+assert.equal(invoke(connected.live).statusCode, 200);
+assert.equal(invoke(connected.ready).statusCode, 200);
+assert.equal(invoke(connected.ready).body.dependencies.mongodb, 'connected');
+
+const disconnected = createHealthHandlers({ connection: { readyState: 0 } });
+const unavailable = invoke(disconnected.ready);
+assert.equal(unavailable.statusCode, 503);
+assert.equal(unavailable.body.status, 'not_ready');
+assert.equal(unavailable.body.dependencies.mongodb, 'disconnected');
+
+console.log('Health endpoint tests passed.');


### PR DESCRIPTION
### Summary

Adds separate liveness and dependency-aware readiness endpoints for deployment probes and monitoring.

### Problem

The existing health endpoint always returned HTTP 200, even when MongoDB was disconnected. Orchestrators could continue routing traffic to an API instance unable to serve database-backed requests.

### Solution

Keep the legacy health path as a liveness probe and add explicit `/live` and `/ready` endpoints. Readiness returns HTTP 503 until Mongoose reports an active connection.

### Changes

- Added reusable health handlers with dependency injection for testing.
- Added `GET /api/health/live` for process liveness.
- Added `GET /api/health/ready` for MongoDB readiness.
- Preserved `GET /api/health` as a backward-compatible liveness endpoint.
- Added connected and disconnected regression tests.

### Validation

- `node tests/verifyHealthEndpoints.js` — passed.
- `node --check controllers/healthController.js` — passed.
- `node --check server.js` — passed.
- `git diff --check` — passed.

### Test Cases

- Liveness returns HTTP 200 with uptime metadata.
- Connected MongoDB readiness returns HTTP 200.
- Disconnected MongoDB readiness returns HTTP 503 with dependency state.

### Screenshots

Not applicable.

### Database or Migration Impact

None.

### API Impact

Adds `/api/health/live` and `/api/health/ready`. The legacy `/api/health` endpoint remains compatible.

### Risks and Trade-offs

Readiness intentionally reports unavailable when running in the repository's database-free fallback mode. Deployments that intentionally omit MongoDB should use the liveness endpoint.

### Deployment Notes

Configure container liveness probes to `/api/health/live` and readiness probes to `/api/health/ready`.

### Checklist

- [x] Scope is limited to health reporting.
- [x] Backward compatibility is preserved.
- [x] Connected and disconnected tests were added.
- [x] Relevant tests and syntax checks pass.
- [x] API and deployment impact are documented.
- [x] No migration or environment variable is required.
- [x] No secrets were committed.
- [x] The final diff was reviewed.

Closes #522.
