### PR TITLE
feat: add graceful server shutdown handling

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -31,6 +31,7 @@ import { checkUpcomingBookings } from './workers/bookingReminderWorker.js';
 import favoriteRoutes from './routes/favoriteRoutes.js';
 import estimateRoutes from './routes/estimateRoutes.js';
 import availabilityRoutes from './routes/availabilityRoutes.js';
+import { createGracefulShutdown } from './utils/gracefulShutdown.js';
 import auditLogRoutes from './routes/auditLogRoutes.js';
 import earningRoutes from './routes/earningRoutes.js';
 import moderationRoutes from './routes/moderationRoutes.js';
@@ -212,3 +213,7 @@ initSocket(server);
 server.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });
+
+const shutdown = createGracefulShutdown({ server });
+process.once('SIGTERM', () => shutdown('SIGTERM'));
+process.once('SIGINT', () => shutdown('SIGINT'));

--- a/server/tests/verifyGracefulShutdown.js
+++ b/server/tests/verifyGracefulShutdown.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { createGracefulShutdown } from '../utils/gracefulShutdown.js';
+
+let serverCloseCount = 0;
+let databaseCloseCount = 0;
+const exitCodes = [];
+
+const shutdown = createGracefulShutdown({
+  server: {
+    close(callback) {
+      serverCloseCount += 1;
+      callback();
+    },
+  },
+  closeDatabase: async () => {
+    databaseCloseCount += 1;
+  },
+  exit: (code) => exitCodes.push(code),
+  logger: { info() {}, error() {} },
+  timeoutMs: 100,
+});
+
+const first = shutdown('SIGTERM');
+const second = shutdown('SIGINT');
+assert.equal(first, second);
+assert.equal(await first, 0);
+assert.equal(serverCloseCount, 1);
+assert.equal(databaseCloseCount, 1);
+assert.deepEqual(exitCodes, [0]);
+
+console.log('Graceful shutdown tests passed.');

--- a/server/utils/gracefulShutdown.js
+++ b/server/utils/gracefulShutdown.js
@@ -1,0 +1,45 @@
+import mongoose from 'mongoose';
+
+export const createGracefulShutdown = ({
+  server,
+  closeDatabase = () => mongoose.connection.close(),
+  exit = (code) => process.exit(code),
+  logger = console,
+  timeoutMs = 10000,
+}) => {
+  let shutdownPromise;
+
+  return (signal) => {
+    if (shutdownPromise) return shutdownPromise;
+
+    shutdownPromise = new Promise((resolve) => {
+      logger.info(`Received ${signal}; starting graceful shutdown`);
+
+      const forceTimer = setTimeout(() => {
+        logger.error('Graceful shutdown timed out; forcing exit');
+        exit(1);
+        resolve(1);
+      }, timeoutMs);
+      forceTimer.unref?.();
+
+      server.close(async (serverError) => {
+        let exitCode = serverError ? 1 : 0;
+        if (serverError) logger.error('HTTP server failed to close cleanly', serverError);
+
+        try {
+          await closeDatabase();
+        } catch (databaseError) {
+          exitCode = 1;
+          logger.error('MongoDB connection failed to close cleanly', databaseError);
+        }
+
+        clearTimeout(forceTimer);
+        logger.info('Graceful shutdown complete');
+        exit(exitCode);
+        resolve(exitCode);
+      });
+    });
+
+    return shutdownPromise;
+  };
+};


### PR DESCRIPTION
### Summary

Adds a graceful shutdown lifecycle for container and local termination signals.

### Problem

The API did not handle SIGTERM or SIGINT. Container replacements could terminate active HTTP requests abruptly and leave the MongoDB connection open until the process was killed.

### Solution

Register a single idempotent shutdown coordinator that stops accepting HTTP connections, waits for active requests, closes MongoDB, and exits with an appropriate status. A timeout prevents indefinite shutdown hangs.

### Changes

- Added an injectable graceful shutdown utility.
- Handles SIGTERM and SIGINT once per process.
- Closes the HTTP server before MongoDB.
- Forces a non-zero exit after a ten-second timeout.
- Reports close failures and uses a non-zero exit code.
- Added idempotency and cleanup regression tests.

### Validation

- `node tests/verifyGracefulShutdown.js` — passed.
- `node --check utils/gracefulShutdown.js` — passed.
- `node --check server.js` — passed.
- `git diff --check` — passed.

### Test Cases

- Concurrent shutdown signals share one shutdown operation.
- HTTP server closes once.
- MongoDB closes once.
- Successful cleanup exits with status zero.

### Screenshots

Not applicable.

### Database or Migration Impact

None. This only closes the existing connection during process termination.

### API Impact

None.

### Risks and Trade-offs

The ten-second deadline bounds deployment shutdown time. Requests exceeding that window may still be terminated by the forced exit.

### Deployment Notes

Container termination grace periods should be configured above ten seconds so the application timeout can complete first.

### Checklist

- [x] Implementation is isolated and idempotent.
- [x] Existing HTTP and MongoDB resources are closed in order.
- [x] Regression tests were added.
- [x] Relevant tests and syntax checks pass.
- [x] Deployment behavior is documented.
- [x] No API or schema changes are introduced.
- [x] No secrets were committed.
- [x] The final diff was reviewed.

Closes #520.
