### PR TITLE
feat: add worker profile sharing

### DIFF
--- a/client/src/pages/WorkerProfile.jsx
+++ b/client/src/pages/WorkerProfile.jsx
@@ -21,6 +21,7 @@ import {
   ChevronDown,
   ChevronUp,
   Heart,
+  Share2,
 } from "lucide-react";
 
 import SkeletonLoader from "../components/SkeletonLoader";
@@ -35,7 +36,7 @@ import { getWorkerAvailability } from "../services/availabilityService";
 import { getFavorites, toggleFavorite } from "../services/favoriteService";
 import useToast from "../hooks/useToast";
 import ReviewBadge from "../components/ReviewBadge";
-import ReviewList from "../components/ReviewList";
+import { shareWorkerProfile } from "../utils/shareWorkerProfile";
 
 /* ✅ Move data outside component */
 const WORKERS = {
@@ -539,6 +540,20 @@ const WorkerProfile = () => {
     }
   };
 
+  const handleShareProfile = async () => {
+    try {
+      const result = await shareWorkerProfile({ worker });
+      showToast(
+        result === 'copied' ? 'Profile link copied to clipboard.' : 'Profile shared successfully.',
+        'success',
+      );
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        showToast(error.message || 'Unable to share this profile.', 'error');
+      }
+    }
+  };
+
   const [availableSlots, setAvailableSlots] = useState([]);
   const [selectedSlot, setSelectedSlot] = useState(null);
   const [slotsLoading, setSlotsLoading] = useState(false);
@@ -852,6 +867,15 @@ const WorkerProfile = () => {
                       isSaved ? "fill-red-500 text-red-500" : "text-slate-400"
                     }`}
                   />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleShareProfile}
+                  className="p-2 rounded-full hover:bg-blue-50 text-slate-400 hover:text-blue-600 transition-all focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  aria-label={`Share ${worker.name}'s profile`}
+                  title="Share profile"
+                >
+                  <Share2 className="h-5 w-5" aria-hidden="true" />
                 </button>
               </div>
               <p className="text-blue-600 font-medium">{worker.profession}</p>

--- a/client/src/utils/shareWorkerProfile.js
+++ b/client/src/utils/shareWorkerProfile.js
@@ -1,0 +1,25 @@
+export const createWorkerShareData = (worker, origin = globalThis.location?.origin || '') => ({
+  title: `${worker.name} on FixNearby`,
+  text: `View ${worker.name}, ${worker.profession}, on FixNearby.`,
+  url: `${origin}/worker/${worker._id || worker.id}`,
+});
+
+export const shareWorkerProfile = async ({
+  worker,
+  navigatorObject = globalThis.navigator,
+  origin,
+}) => {
+  const data = createWorkerShareData(worker, origin);
+
+  if (typeof navigatorObject?.share === 'function') {
+    await navigatorObject.share(data);
+    return 'shared';
+  }
+
+  if (typeof navigatorObject?.clipboard?.writeText === 'function') {
+    await navigatorObject.clipboard.writeText(data.url);
+    return 'copied';
+  }
+
+  throw new Error('Sharing is not supported by this browser');
+};

--- a/client/src/utils/shareWorkerProfile.test.js
+++ b/client/src/utils/shareWorkerProfile.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { createWorkerShareData, shareWorkerProfile } from './shareWorkerProfile.js';
+
+const worker = { id: 'worker-1', name: 'Asha', profession: 'Electrician' };
+assert.deepEqual(createWorkerShareData(worker, 'https://fixnearby.example'), {
+  title: 'Asha on FixNearby',
+  text: 'View Asha, Electrician, on FixNearby.',
+  url: 'https://fixnearby.example/worker/worker-1',
+});
+
+let sharedData;
+assert.equal(await shareWorkerProfile({
+  worker,
+  origin: 'https://fixnearby.example',
+  navigatorObject: { share: async (data) => { sharedData = data; } },
+}), 'shared');
+assert.equal(sharedData.url, 'https://fixnearby.example/worker/worker-1');
+
+let copiedUrl;
+assert.equal(await shareWorkerProfile({
+  worker,
+  origin: 'https://fixnearby.example',
+  navigatorObject: { clipboard: { writeText: async (url) => { copiedUrl = url; } } },
+}), 'copied');
+assert.equal(copiedUrl, 'https://fixnearby.example/worker/worker-1');
+
+console.log('Worker profile sharing tests passed.');


### PR DESCRIPTION
### Summary

Adds native and clipboard-based sharing for worker profile pages.

### Problem

Users could save or book professionals but had no direct way to send a profile to family, neighbors, or collaborators.

### Solution

Add an accessible share action beside the existing favorite control. Browsers with the Web Share API receive the native share sheet; desktop browsers fall back to copying the canonical profile URL.

### Changes

- Added deterministic worker profile share metadata and URLs.
- Added Web Share API support.
- Added clipboard fallback and unsupported-browser handling.
- Added success, copy, error, and cancellation feedback behavior.
- Added an accessible share button to WorkerProfile.
- Removed a duplicate ReviewList import that prevented the affected page from parsing.
- Added native-share and clipboard regression tests.

### Validation

- `node src/utils/shareWorkerProfile.test.js` — passed.
- `npx eslint src/pages/WorkerProfile.jsx src/utils/shareWorkerProfile.js src/utils/shareWorkerProfile.test.js --report-unused-disable-directives --max-warnings 0` — passed.
- `git diff --check` — passed.

### Test Cases

- Share metadata contains the worker name, profession, and canonical URL.
- Supported browsers invoke the native share API.
- Browsers without native sharing copy the URL.
- User-cancelled native shares do not show an error toast.

### Screenshots

Not included; the new action reuses the existing circular profile action styling.

### Database or Migration Impact

None.

### API Impact

None.

### Risks and Trade-offs

Clipboard fallback requires browser clipboard permission. Unsupported browsers receive a clear error without affecting the profile page.

### Deployment Notes

The Web Share and Clipboard APIs generally require HTTPS outside localhost, which matches production deployment expectations.

### Checklist

- [x] Implementation is limited to profile sharing.
- [x] Native platform capabilities are preferred with a fallback.
- [x] Accessibility labeling is included.
- [x] Regression tests were added.
- [x] Targeted lint and tests pass.
- [x] No API or database changes are required.
- [x] No secrets were committed.
- [x] The final diff was reviewed.
