### PR TITLE
feat: add account data export

### DIFF
--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,13 +1,15 @@
 import { useState } from "react";
 import { useAuth } from "../context/AuthContext";
-import { updateProfile } from "../services/authService";
+import { exportProfileData, updateProfile } from "../services/authService";
 import useToast from "../hooks/useToast";
+import { downloadJson } from "../utils/downloadJson";
 
 const Profile = () => {
   const { user, login } = useAuth();
   const { showToast } = useToast();
 
   const [loading, setLoading] = useState(false);
+  const [exporting, setExporting] = useState(false);
 
   const [formData, setFormData] = useState({
     name: user?.name || "",
@@ -36,6 +38,22 @@ const Profile = () => {
       showToast(error.message || "Failed to update profile", "error");
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleExportData = async () => {
+    setExporting(true);
+    try {
+      const data = await exportProfileData();
+      downloadJson({
+        data,
+        filename: `fixnearby-account-${new Date().toISOString().slice(0, 10)}.json`,
+      });
+      showToast('Account data downloaded successfully!', 'success');
+    } catch (error) {
+      showToast(error.message || 'Failed to export account data', 'error');
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -113,6 +131,21 @@ const Profile = () => {
           </div>
         </form>
       </div>
+
+      <section className="mt-6 rounded-lg bg-white p-6 shadow" aria-labelledby="account-data-heading">
+        <h2 id="account-data-heading" className="text-xl font-semibold text-gray-900">Your data</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Download a JSON copy of your account details and notification preferences.
+        </p>
+        <button
+          type="button"
+          onClick={handleExportData}
+          disabled={exporting}
+          className="mt-5 rounded border border-blue-600 px-4 py-2 font-bold text-blue-600 hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {exporting ? 'Preparing download...' : 'Download My Data'}
+        </button>
+      </section>
     </div>
   );
 };

--- a/client/src/services/authService.js
+++ b/client/src/services/authService.js
@@ -36,6 +36,15 @@ export const getProfile = async () => {
   }
 };
 
+export const exportProfileData = async () => {
+  try {
+    const response = await api.get('/auth/profile/export');
+    return response.data;
+  } catch (error) {
+    throw createServiceError(error, 'Failed to export account data');
+  }
+};
+
 export const updateProfile = async (data) => {
   try {
     const response = await api.put("/auth/profile", data);
@@ -99,4 +108,3 @@ export const resetWorkerPassword = async (token, password) => {
     throw createServiceError(error, "Failed to reset password");
   }
 };
-

--- a/client/src/utils/downloadJson.js
+++ b/client/src/utils/downloadJson.js
@@ -1,0 +1,18 @@
+export const downloadJson = ({
+  data,
+  filename,
+  documentObject = globalThis.document,
+  urlObject = globalThis.URL,
+}) => {
+  if (!documentObject || !urlObject) {
+    throw new Error('File downloads are not supported in this environment');
+  }
+
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = urlObject.createObjectURL(blob);
+  const anchor = documentObject.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  urlObject.revokeObjectURL(url);
+};

--- a/client/src/utils/downloadJson.test.js
+++ b/client/src/utils/downloadJson.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { downloadJson } from './downloadJson.js';
+
+let clicked = false;
+let revokedUrl;
+const anchor = { click: () => { clicked = true; } };
+const documentObject = { createElement: () => anchor };
+const urlObject = {
+  createObjectURL: () => 'blob:test-export',
+  revokeObjectURL: (url) => { revokedUrl = url; },
+};
+
+downloadJson({
+  data: { account: { name: 'Test User' } },
+  filename: 'account.json',
+  documentObject,
+  urlObject,
+});
+
+assert.equal(anchor.download, 'account.json');
+assert.equal(anchor.href, 'blob:test-export');
+assert.equal(clicked, true);
+assert.equal(revokedUrl, 'blob:test-export');
+
+console.log('JSON download tests passed.');

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -171,6 +171,32 @@ export const getUserProfile = async (req, res) => {
   }
 };
 
+export const buildUserDataExport = (user, exportedAt = new Date()) => ({
+  schemaVersion: 1,
+  exportedAt: exportedAt.toISOString(),
+  account: {
+    id: String(user._id),
+    name: user.name,
+    email: user.email,
+    phone: user.phone || null,
+    role: user.role,
+    status: user.status,
+    notificationPreferences:
+      user.notificationPreferences?.toObject?.() || user.notificationPreferences || {},
+    createdAt: user.createdAt || null,
+    updatedAt: user.updatedAt || null,
+  },
+});
+
+export const exportUserData = (req, res) => {
+  const data = buildUserDataExport(req.user);
+  const date = data.exportedAt.slice(0, 10);
+
+  res.setHeader('Content-Disposition', `attachment; filename="fixnearby-account-${date}.json"`);
+  res.setHeader('Cache-Control', 'no-store');
+  return res.status(200).json(data);
+};
+
 export const updateUserProfile = async (req, res) => {
   try {
     if (req.body.password && !isValidPassword(req.body.password)) {

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -4,6 +4,7 @@ import {
   registerUser,
   loginUser,
   getUserProfile,
+  exportUserData,
   updateUserProfile,
   forgotUserPassword,
   resetUserPassword,
@@ -57,6 +58,7 @@ router.get('/csrf-token', (req, res) => {
 router.post('/register', userRegisterLimiter, validateRegistration, registerUser);
 router.post('/login', userLoginLimiter, validateLogin, loginUser);
 router.get('/profile', protect, getUserProfile);
+router.get('/profile/export', protect, exportUserData);
 router.put('/profile', protect, profileUpdateLimiter, updateUserProfile);
 router.post('/logout', protect, logoutLimiter, logoutUser);
 

--- a/server/tests/verifyUserDataExport.js
+++ b/server/tests/verifyUserDataExport.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { buildUserDataExport } from '../controllers/authController.js';
+
+const exported = buildUserDataExport({
+  _id: '507f1f77bcf86cd799439011',
+  name: 'Test User',
+  email: 'test@example.com',
+  phone: '9876543210',
+  role: 'customer',
+  status: 'offline',
+  notificationPreferences: { email: true, sms: false, push: true },
+  password: 'must-not-export',
+  resetPasswordToken: 'must-not-export',
+}, new Date('2026-07-17T00:00:00.000Z'));
+
+assert.equal(exported.schemaVersion, 1);
+assert.equal(exported.exportedAt, '2026-07-17T00:00:00.000Z');
+assert.equal(exported.account.email, 'test@example.com');
+assert.equal(exported.account.notificationPreferences.sms, false);
+assert.equal('password' in exported.account, false);
+assert.equal('resetPasswordToken' in exported.account, false);
+
+console.log('User data export tests passed.');


### PR DESCRIPTION
### Summary

Adds authenticated account data export from the Profile page as a portable JSON download.

### Problem

Users can edit account information but have no way to retrieve a structured copy of the personal data and preferences FixNearby stores for them.

### Solution

Expose an allowlisted export endpoint and add a Profile action that downloads the response locally. The export intentionally includes only user-facing account fields and excludes passwords, password-reset tokens, JWTs, and internal authentication data.

### Changes

- Added `GET /api/auth/profile/export` behind existing authentication middleware.
- Added a versioned account export schema with an export timestamp.
- Added `Cache-Control: no-store` and an attachment filename.
- Added a client export service and reusable JSON download utility.
- Added an accessible “Download My Data” Profile section with loading and error states.
- Added backend sensitive-field regression coverage.
- Added frontend download behavior coverage.

### Validation

- `node tests/verifyUserDataExport.js` — passed.
- `node --check controllers/authController.js` — passed.
- `node --check routes/authRoutes.js` — passed.
- `node src/utils/downloadJson.test.js` — passed.
- `npx eslint src/pages/Profile.jsx src/services/authService.js src/utils/downloadJson.js src/utils/downloadJson.test.js --report-unused-disable-directives --max-warnings 0` — passed.
- `git diff --check` — passed.
- Full client lint/build remain blocked by pre-existing duplicate declarations in `Bookings.jsx` and `WorkerProfile.jsx`, unrelated to this PR.

### Test Cases

- Export includes account identity, contact details, role, status, timestamps, and notification preferences.
- Export schema and timestamp are deterministic when tested.
- Password and reset-token fields are absent.
- Browser download receives the expected filename and revokes its object URL.

### Screenshots

Not included because the upstream client build is currently blocked by the documented unrelated duplicate declarations. The new section reuses existing Profile card styling.

### Database or Migration Impact

None. The endpoint reads the already authenticated user document and does not modify data.

### API Impact

Adds authenticated `GET /api/auth/profile/export`. Existing endpoints and response formats are unchanged.

### Risks and Trade-offs

The first schema version exports account-level data only; bookings, reviews, and messages are not included. The schema version allows those categories to be added compatibly later.

### Deployment Notes

No migration, environment variable, background job, or deployment ordering is required.

### Checklist

- [x] Implementation is limited to account data export.
- [x] Authentication is required.
- [x] Sensitive fields are excluded through an explicit allowlist.
- [x] Responses disable caching.
- [x] Backend and frontend tests were added.
- [x] Targeted lint and syntax checks pass.
- [x] API limitations are documented.
- [x] No secrets were committed.
- [x] The final diff was reviewed.
