### PR TITLE
Fix silent demo-token fallback in auth service (#922)

### DIFF
--- a/client/src/services/authService.js
+++ b/client/src/services/authService.js
@@ -9,75 +9,37 @@ const createServiceError = (error, fallbackMessage) => {
 export const signupUser = async (data) => {
   try {
     const response = await api.post("/auth/register", data);
-    if (response.data && typeof response.data === 'object' && (response.data._id || response.data.user || response.data.token)) {
-      const u = response.data.user || response.data;
-      return {
-        _id: u._id || u.id || 'user_' + Date.now(),
-        name: u.name || data.name || 'User',
-        email: u.email || data.email,
-        phone: u.phone || data.phone || '',
-        role: u.role || 'user',
-        token: response.data.token || u.token || 'demo_token_' + Date.now(),
-        ...response.data,
-      };
-    }
+    const u = response.data.user || response.data;
     return {
-      _id: 'user_' + Date.now(),
-      name: data.name || 'User',
-      email: data.email || 'user@example.com',
-      phone: data.phone || '',
-      role: 'user',
-      token: 'demo_token_' + Date.now(),
+      _id: u._id || u.id,
+      name: u.name || data.name,
+      email: u.email || data.email,
+      phone: u.phone || data.phone || '',
+      role: u.role || 'user',
+      token: response.data.token || u.token,
+      ...response.data,
     };
   } catch (error) {
     console.error('[signupUser]', error);
-    if (error.response?.data?.message && error.response.status === 400) {
-      throw createServiceError(error, error.response.data.message);
-    }
-    return {
-      _id: 'user_' + Date.now(),
-      name: data.name || 'User',
-      email: data.email || 'user@example.com',
-      phone: data.phone || '',
-      role: 'user',
-      token: 'demo_token_' + Date.now(),
-    };
+    throw createServiceError(error, "Registration failed. Please try again.");
   }
 };
 
 export const loginUser = async (data) => {
   try {
     const response = await api.post("/auth/login", data);
-    if (response.data && typeof response.data === 'object' && (response.data._id || response.data.user || response.data.token)) {
-      const u = response.data.user || response.data;
-      return {
-        _id: u._id || u.id || 'user_101',
-        name: u.name || (data.email ? data.email.split('@')[0] : 'User'),
-        email: u.email || data.email,
-        role: u.role || 'user',
-        token: response.data.token || u.token || 'demo_token_' + Date.now(),
-        ...response.data,
-      };
-    }
+    const u = response.data.user || response.data;
     return {
-      _id: 'user_101',
-      name: data.email ? data.email.split('@')[0] : 'User',
-      email: data.email || 'user@example.com',
-      role: 'user',
-      token: 'demo_token_' + Date.now(),
+      _id: u._id || u.id,
+      name: u.name || (data.email ? data.email.split('@')[0] : 'User'),
+      email: u.email || data.email,
+      role: u.role || 'user',
+      token: response.data.token || u.token,
+      ...response.data,
     };
   } catch (error) {
     console.error('[loginUser]', error);
-    if (error.response?.data?.message && (error.response.status === 400 || error.response.status === 401)) {
-      throw createServiceError(error, error.response.data.message);
-    }
-    return {
-      _id: 'user_101',
-      name: data.email ? data.email.split('@')[0] : 'User',
-      email: data.email || 'user@example.com',
-      role: 'user',
-      token: 'demo_token_' + Date.now(),
-    };
+    throw createServiceError(error, "Login failed. Please check your credentials.");
   }
 };
 
@@ -110,13 +72,9 @@ export const updateNotificationPreferences = async (preferences) => {
   }
 };
 
-
 export const forgotUserPassword = async (email) => {
   try {
-    const response = await api.post("/auth/forgot-password", {
-      email,
-    });
-
+    const response = await api.post("/auth/forgot-password", { email });
     return response.data;
   } catch (error) {
     throw createServiceError(error, "Failed to send reset link");
@@ -125,26 +83,16 @@ export const forgotUserPassword = async (email) => {
 
 export const resetUserPassword = async (token, password) => {
   try {
-    const response = await api.put(
-      `/auth/reset-password/${token}`,
-      { password }
-    );
-
+    const response = await api.put(`/auth/reset-password/${token}`, { password });
     return response.data;
   } catch (error) {
     throw createServiceError(error, "Failed to reset password");
   }
 };
 
-
-
 export const forgotWorkerPassword = async (email) => {
   try {
-    const response = await api.post(
-      "/auth/worker/forgot-password",
-      { email }
-    );
-
+    const response = await api.post("/auth/worker/forgot-password", { email });
     return response.data;
   } catch (error) {
     throw createServiceError(error, "Failed to send reset link");
@@ -153,11 +101,7 @@ export const forgotWorkerPassword = async (email) => {
 
 export const resetWorkerPassword = async (token, password) => {
   try {
-    const response = await api.put(
-      `/auth/worker/reset-password/${token}`,
-      { password }
-    );
-
+    const response = await api.put(`/auth/worker/reset-password/${token}`, { password });
     return response.data;
   } catch (error) {
     throw createServiceError(error, "Failed to reset password");


### PR DESCRIPTION
Closes #922

## What
Login/Register already called the real backend endpoints, but `authService.js` had a
silent fallback that returned fake success data (with a `demo_token_...`) whenever a
non-400 error occurred (network failure, timeout, 500, CORS). This meant users could
appear "logged in" via localStorage even though the backend never authenticated them.

## Fix
- Removed the fake-success fallback objects in `signupUser` and `loginUser`
- Both now throw a proper error on any failed request, surfaced via the existing
  `parseApiError` handling already wired up in `Login.jsx` / `Register.jsx`

## Testing
- Verified successful login/register still work end-to-end
- Verified stopping the backend now shows a real error instead of a fake login